### PR TITLE
feat: add comment delete endpoint

### DIFF
--- a/apps/wish-app/convex/http.ts
+++ b/apps/wish-app/convex/http.ts
@@ -155,6 +155,8 @@ app.delete("/api/project/:id/request/:reqID/comment/:commentId", async (c) => {
 
     await c.env.runMutation(api.requestComments.deleteByClient, {
       id: commentId as Id<"requestComments">,
+      requestId: reqId as Id<"requests">,
+      projectId: id as Id<"projects">,
       clientId: clientId || undefined,
     });
   } catch {

--- a/apps/wish-app/convex/http.ts
+++ b/apps/wish-app/convex/http.ts
@@ -142,6 +142,28 @@ app.post(
   },
 );
 
+app.delete("/api/project/:id/request/:reqID/comment/:commentId", async (c) => {
+  const id = c.req.param("id");
+  const reqId = c.req.param("reqID");
+  const commentId = c.req.param("commentId");
+  const clientId = c.req.query("clientId");
+  const authHeader = c.req.header("Authorization");
+
+  try {
+    if (!id || !reqId || !commentId) throw new Error("invalid request id");
+    if (!clientId && !authHeader) throw new Error("client id or auth is required");
+
+    await c.env.runMutation(api.requestComments.deleteByClient, {
+      id: commentId as Id<"requestComments">,
+      clientId: clientId || undefined,
+    });
+  } catch {
+    return c.json({}, 400);
+  }
+
+  return c.json({}, 200);
+});
+
 app.post(
   "/api/project/:id/request/:reqID/upvote",
   arktypeValidator("json", UpvoteValidator),


### PR DESCRIPTION
## Summary\n- Add public comment delete endpoint for client-owned comments\n- Enforce ownership in mutation for public clients (auth still allowed)\n\n## Testing\n- bun lint:strict && bun check-types && bun build failed locally (oxlint not installed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment deletion now available. Users and clients can delete their own comments from project requests with proper ownership validation to ensure only comment authors can remove their contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->