### PR TITLE
feat: add changelog destination to the iOS embed (WishDestination.changelog)

### DIFF
--- a/apps/wish-start/src/lib/embedApi.test.ts
+++ b/apps/wish-start/src/lib/embedApi.test.ts
@@ -4,6 +4,7 @@ import {
   createEmbedComment,
   createEmbedRequest,
   EmbedApiError,
+  getEmbedChangelog,
   listEmbedRequests,
   listEmbedUpvotedRequestIds,
   toggleEmbedUpvote,
@@ -109,5 +110,29 @@ describe("embedApi", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
 
     await expect(listEmbedRequests(config)).rejects.toBeInstanceOf(EmbedApiError);
+  });
+
+  it("fetches the changelog feed and sends the client key as x-api-key, never in the URL", async () => {
+    const fetchMock = mockFetch({
+      project: { title: "My Project", publicChangelogSlug: "my-project" },
+      entries: [{ versionLabel: "1.0.0", title: "Launch", type: "feature" }],
+    });
+
+    const feed = await getEmbedChangelog(config);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.convex.site/api/project/proj_123/changelog");
+    expect(url).not.toContain(config.clientKey);
+    expect(init.headers["x-api-key"]).toBe(config.clientKey);
+    expect(feed.project).toEqual({ title: "My Project", publicChangelogSlug: "my-project" });
+    expect(feed.entries).toEqual([{ versionLabel: "1.0.0", title: "Launch", type: "feature" }]);
+  });
+
+  it("maps a missing or invalid entries field to an empty array", async () => {
+    mockFetch({ project: { title: "My Project" }, entries: "not-an-array" });
+
+    const feed = await getEmbedChangelog(config);
+
+    expect(feed.entries).toEqual([]);
   });
 });

--- a/apps/wish-start/src/lib/embedApi.ts
+++ b/apps/wish-start/src/lib/embedApi.ts
@@ -23,6 +23,20 @@ export type EmbedComment = {
   createdAt: number;
 };
 
+export type EmbedChangelogEntry = {
+  versionLabel: string;
+  title: string;
+  summary?: string;
+  body?: string;
+  type: "feature" | "improvement" | "fix";
+  publishedAt?: number;
+};
+
+export type EmbedChangelogFeed = {
+  project: { title: string; publicChangelogSlug?: string };
+  entries: EmbedChangelogEntry[];
+};
+
 export class EmbedApiError extends Error {
   code: string;
 
@@ -115,4 +129,10 @@ export async function toggleEmbedUpvote(config: EmbedApiConfig, requestId: strin
     method: "POST",
     body: JSON.stringify({ clientId: config.clientId }),
   });
+}
+
+export async function getEmbedChangelog(config: EmbedApiConfig): Promise<EmbedChangelogFeed> {
+  const payload = await embedFetch(config, "/changelog");
+  const entries: EmbedChangelogEntry[] = Array.isArray(payload?.entries) ? payload.entries : [];
+  return { project: payload.project, entries };
 }

--- a/apps/wish-start/src/routes/embed.tsx
+++ b/apps/wish-start/src/routes/embed.tsx
@@ -13,12 +13,13 @@ import { getConvexHttpBaseUrl } from "@/lib/convexHttp";
 import {
   createEmbedComment,
   createEmbedRequest,
+  getEmbedChangelog,
   listEmbedComments,
   listEmbedRequests,
   listEmbedUpvotedRequestIds,
   toggleEmbedUpvote,
   type EmbedApiConfig,
-  type EmbedComment,
+  type EmbedChangelogEntry,
   type EmbedRequest,
 } from "@/lib/embedApi";
 import { formatDate } from "@/lib/time";
@@ -35,6 +36,7 @@ export const Route = createFileRoute("/embed")({
     projectId: typeof search.projectId === "string" ? search.projectId : undefined,
     clientId: typeof search.clientId === "string" ? search.clientId : undefined,
     clientKey: typeof search.clientKey === "string" ? search.clientKey : undefined,
+    view: search.view === "changelog" ? ("changelog" as const) : ("requests" as const),
   }),
   component: EmbedPage,
 });
@@ -44,8 +46,29 @@ type EmbedScreen =
   | { name: "new" }
   | { name: "detail"; requestId: string };
 
+function useEmbedResource<T>(loader: () => Promise<T>) {
+  const [data, setData] = useState<T | undefined>();
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoadError(null);
+    setData(undefined);
+    try {
+      setData(await loader());
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : "Something went wrong.");
+    }
+  }, [loader]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { data, setData, loadError, reload };
+}
+
 function EmbedPage() {
-  const { projectId, clientId, clientKey } = Route.useSearch();
+  const { projectId, clientId, clientKey, view } = Route.useSearch();
   const baseUrl = getConvexHttpBaseUrl(env.VITE_CONVEX_URL);
   const config = useMemo(
     () =>
@@ -66,55 +89,48 @@ function EmbedPage() {
     );
   }
 
-  return <EmbedRequestsApp config={config} />;
+  return view === "changelog" ? <EmbedChangelogApp config={config} /> : <EmbedRequestsApp config={config} />;
 }
 
 function EmbedRequestsApp({ config }: { config: EmbedApiConfig }) {
-  const [requests, setRequests] = useState<EmbedRequest[] | undefined>();
-  const [upvoted, setUpvoted] = useState<Set<string>>(new Set());
-  const [loadError, setLoadError] = useState<string | null>(null);
   const [screen, setScreen] = useState<EmbedScreen>({ name: "list" });
 
-  const load = useCallback(async () => {
-    setLoadError(null);
-    setRequests(undefined);
-    try {
-      const [nextRequests, nextUpvoted] = await Promise.all([
-        listEmbedRequests(config),
-        listEmbedUpvotedRequestIds(config),
-      ]);
-      nextRequests.sort((a, b) => b._creationTime - a._creationTime);
-      setRequests(nextRequests);
-      setUpvoted(nextUpvoted);
-    } catch (error) {
-      setLoadError(error instanceof Error ? error.message : "Something went wrong.");
-    }
+  const loadRequests = useCallback(async () => {
+    const [nextRequests, nextUpvoted] = await Promise.all([
+      listEmbedRequests(config),
+      listEmbedUpvotedRequestIds(config),
+    ]);
+    nextRequests.sort((a, b) => b._creationTime - a._creationTime);
+    return { requests: nextRequests, upvoted: nextUpvoted };
   }, [config]);
 
-  useEffect(() => {
-    void load();
-  }, [load]);
+  const { data, setData, loadError, reload } = useEmbedResource(loadRequests);
+  const requests = data?.requests;
+  const upvoted = data?.upvoted ?? new Set<string>();
 
   async function handleUpvote(requestId: string) {
     const wasUpvoted = upvoted.has(requestId);
-    setUpvoted((current) => {
-      const next = new Set(current);
-      if (wasUpvoted) next.delete(requestId);
-      else next.add(requestId);
-      return next;
+    setData((current) => {
+      if (!current) {
+        return current;
+      }
+      const nextUpvoted = new Set(current.upvoted);
+      if (wasUpvoted) nextUpvoted.delete(requestId);
+      else nextUpvoted.add(requestId);
+      return {
+        upvoted: nextUpvoted,
+        requests: current.requests.map((request) =>
+          request._id === requestId
+            ? { ...request, upvoteCount: Math.max(0, (request.upvoteCount ?? 0) + (wasUpvoted ? -1 : 1)) }
+            : request,
+        ),
+      };
     });
-    setRequests((current) =>
-      current?.map((request) =>
-        request._id === requestId
-          ? { ...request, upvoteCount: Math.max(0, (request.upvoteCount ?? 0) + (wasUpvoted ? -1 : 1)) }
-          : request,
-      ),
-    );
 
     try {
       await toggleEmbedUpvote(config, requestId);
     } catch {
-      void load();
+      void reload();
     }
   }
 
@@ -122,7 +138,7 @@ function EmbedRequestsApp({ config }: { config: EmbedApiConfig }) {
     return (
       <EmbedShell>
         <EmbedNotice title="Could not load feedback" description={loadError}>
-          <Button type="button" variant="outline" size="sm" onClick={() => void load()}>
+          <Button type="button" variant="outline" size="sm" onClick={() => void reload()}>
             Retry
           </Button>
         </EmbedNotice>
@@ -148,7 +164,7 @@ function EmbedRequestsApp({ config }: { config: EmbedApiConfig }) {
           onBack={() => setScreen({ name: "list" })}
           onCreated={() => {
             setScreen({ name: "list" });
-            void load();
+            void reload();
           }}
         />
       </EmbedShell>
@@ -246,25 +262,12 @@ function EmbedRequestDetail({
   onUpvote: () => void;
   onBack: () => void;
 }) {
-  const [comments, setComments] = useState<EmbedComment[] | undefined>();
-  const [commentsError, setCommentsError] = useState<string | null>(null);
   const [commentText, setCommentText] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
 
-  const loadComments = useCallback(async () => {
-    setCommentsError(null);
-    setComments(undefined);
-    try {
-      setComments(await listEmbedComments(config, request._id));
-    } catch (error) {
-      setCommentsError(error instanceof Error ? error.message : "Something went wrong.");
-    }
-  }, [config, request._id]);
-
-  useEffect(() => {
-    void loadComments();
-  }, [loadComments]);
+  const loadComments = useCallback(() => listEmbedComments(config, request._id), [config, request._id]);
+  const { data: comments, loadError: commentsError, reload: reloadComments } = useEmbedResource(loadComments);
 
   async function submitComment(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -278,7 +281,7 @@ function EmbedRequestDetail({
     try {
       await createEmbedComment(config, request._id, body);
       setCommentText("");
-      await loadComments();
+      await reloadComments();
     } catch (error) {
       setSendError(error instanceof Error ? error.message : "Could not post the comment.");
     } finally {
@@ -319,7 +322,7 @@ function EmbedRequestDetail({
 
         {commentsError ? (
           <EmbedNotice title="Could not load comments" description={commentsError}>
-            <Button type="button" variant="outline" size="sm" onClick={() => void loadComments()}>
+            <Button type="button" variant="outline" size="sm" onClick={() => void reloadComments()}>
               Retry
             </Button>
           </EmbedNotice>
@@ -426,6 +429,71 @@ function EmbedNewRequest({
         </Button>
       </form>
     </div>
+  );
+}
+
+function EmbedChangelogApp({ config }: { config: EmbedApiConfig }) {
+  const loadFeed = useCallback(() => getEmbedChangelog(config), [config]);
+  const { data: feed, loadError, reload } = useEmbedResource(loadFeed);
+
+  if (loadError) {
+    return (
+      <EmbedShell>
+        <EmbedNotice title="Could not load updates" description={loadError}>
+          <Button type="button" variant="outline" size="sm" onClick={() => void reload()}>
+            Retry
+          </Button>
+        </EmbedNotice>
+      </EmbedShell>
+    );
+  }
+
+  if (feed === undefined) {
+    return (
+      <EmbedShell>
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6 text-muted-foreground" />
+        </div>
+      </EmbedShell>
+    );
+  }
+
+  return (
+    <EmbedShell>
+      <div>
+        <h1 className="text-lg font-semibold tracking-tight">What's new</h1>
+        {feed.project.title ? <p className="text-sm text-muted-foreground">{feed.project.title}</p> : null}
+      </div>
+
+      <Separator className="my-4" />
+
+      {feed.entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No published updates yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {feed.entries.map((entry) => (
+            <EmbedChangelogEntryCard key={entry.versionLabel} entry={entry} />
+          ))}
+        </div>
+      )}
+    </EmbedShell>
+  );
+}
+
+function EmbedChangelogEntryCard({ entry }: { entry: EmbedChangelogEntry }) {
+  return (
+    <article className="space-y-2 rounded-lg border bg-card p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline">{entry.versionLabel}</Badge>
+        <Badge variant="secondary" className="capitalize">
+          {entry.type}
+        </Badge>
+        <time className="text-xs text-muted-foreground">{formatDate(entry.publishedAt)}</time>
+      </div>
+      <h2 className="text-sm font-semibold tracking-tight">{entry.title}</h2>
+      {entry.summary ? <p className="text-sm text-muted-foreground">{entry.summary}</p> : null}
+      {entry.body ? <div className="whitespace-pre-wrap text-sm text-foreground/90">{entry.body}</div> : null}
+    </article>
   );
 }
 

--- a/packages/convex-backend/convex/_generated/api.d.ts
+++ b/packages/convex-backend/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as complaintCases from "../complaintCases.js";
 import type * as http from "../http.js";
 import type * as lib_apiKeys from "../lib/apiKeys.js";
 import type * as lib_authorization from "../lib/authorization.js";
+import type * as lib_changelogIntake from "../lib/changelogIntake.js";
 import type * as lib_notificationEventTypes from "../lib/notificationEventTypes.js";
 import type * as lib_notificationTokens from "../lib/notificationTokens.js";
 import type * as lib_notificationTypes from "../lib/notificationTypes.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/apiKeys": typeof lib_apiKeys;
   "lib/authorization": typeof lib_authorization;
+  "lib/changelogIntake": typeof lib_changelogIntake;
   "lib/notificationEventTypes": typeof lib_notificationEventTypes;
   "lib/notificationTokens": typeof lib_notificationTokens;
   "lib/notificationTypes": typeof lib_notificationTypes;

--- a/packages/convex-backend/convex/changelogEntries.ts
+++ b/packages/convex-backend/convex/changelogEntries.ts
@@ -313,3 +313,17 @@ export const getPublicBySlugInternal = internalQuery({
     return await getPublicFeedBySlug(ctx, args.slug);
   },
 });
+
+export const listPublishedByProjectInternal = internalQuery({
+  args: {
+    projectId: v.id("projects"),
+  },
+  handler: async (ctx, args) => {
+    const entries = await ctx.db
+      .query("changelogEntries")
+      .withIndex("by_project_status", (q) => q.eq("projectId", args.projectId).eq("status", "published"))
+      .collect();
+
+    return entries.sort(sortEntriesByRecent).map((entry) => toPublicChangelogEntry(entry));
+  },
+});

--- a/packages/convex-backend/convex/http.ts
+++ b/packages/convex-backend/convex/http.ts
@@ -17,6 +17,7 @@ import {
   listUpvotes,
   toggleUpvote,
 } from "./lib/requestIntake";
+import { listPublicChangelog } from "./lib/changelogIntake";
 import { toPublicProject } from "./lib/projectPublic";
 import {
   createPublicError,
@@ -64,6 +65,22 @@ app.get("/api/project/:id/requests/", async (c) => {
     }
 
     return c.json({ project: toPublicProject(result.project), requests: result.requests });
+  } catch (error) {
+    return publicErrorJson(c, toPublicErrorResponse(error));
+  }
+});
+
+app.get("/api/project/:id/changelog", async (c) => {
+  try {
+    const id = c.req.param("id");
+    requirePublicId(id);
+
+    const result = await listPublicChangelog(c, id);
+    if (!result.ok) {
+      return publicErrorJson(c, result.error);
+    }
+
+    return c.json({ project: result.project, entries: result.entries });
   } catch (error) {
     return publicErrorJson(c, toPublicErrorResponse(error));
   }

--- a/packages/convex-backend/convex/lib/changelogIntake.ts
+++ b/packages/convex-backend/convex/lib/changelogIntake.ts
@@ -1,0 +1,23 @@
+import { internal } from "../_generated/api";
+import type { ProjectKeyAuthorizationContext } from "./projectKeyAuthorization";
+import { authorizeProjectKeyRequest } from "./projectKeyAuthorization";
+
+export async function listPublicChangelog(c: ProjectKeyAuthorizationContext, projectId: string) {
+  const authorization = await authorizeProjectKeyRequest(c, projectId, "read");
+  if (!authorization.ok) {
+    return authorization;
+  }
+
+  const entries = await c.env.runQuery(internal.changelogEntries.listPublishedByProjectInternal, {
+    projectId: authorization.project._id,
+  });
+
+  return {
+    ok: true as const,
+    project: {
+      title: authorization.project.title,
+      publicChangelogSlug: authorization.project.publicChangelogSlug,
+    },
+    entries,
+  };
+}

--- a/packages/convex-backend/convex/lib/projectKeyAuthorization.ts
+++ b/packages/convex-backend/convex/lib/projectKeyAuthorization.ts
@@ -9,7 +9,7 @@ export const IP_RATE_LIMIT = { limit: 240, windowMs: 60_000 };
 
 export type ProjectOperationScope = "read" | "write" | "admin";
 
-type ProjectKeyAuthorizationContext = {
+export type ProjectKeyAuthorizationContext = {
   req: {
     header(name: string): string | undefined;
   };

--- a/packages/convex-backend/convex/lib/requestIntake.ts
+++ b/packages/convex-backend/convex/lib/requestIntake.ts
@@ -1,17 +1,10 @@
-import type { ActionCtx } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import { createPublicError } from "./publicErrors";
+import type { ProjectKeyAuthorizationContext } from "./projectKeyAuthorization";
 import { authorizeProjectKeyRequest } from "./projectKeyAuthorization";
 
-type RequestIntakeContext = {
-  req: {
-    header(name: string): string | undefined;
-  };
-  env: Pick<ActionCtx, "runQuery" | "runMutation">;
-};
-
-export async function listRequests(c: RequestIntakeContext, projectId: string) {
+export async function listRequests(c: ProjectKeyAuthorizationContext, projectId: string) {
   const authorization = await authorizeProjectKeyRequest(c, projectId, "read");
   if (!authorization.ok) {
     return authorization;
@@ -35,7 +28,7 @@ export async function listRequests(c: RequestIntakeContext, projectId: string) {
 }
 
 async function assertRequestBelongsToProject(
-  c: RequestIntakeContext,
+  c: ProjectKeyAuthorizationContext,
   requestId: string,
   projectId: string,
 ): Promise<Id<"requests">> {
@@ -50,7 +43,7 @@ async function assertRequestBelongsToProject(
   return request._id;
 }
 
-async function getInitialStatusId(c: RequestIntakeContext, projectId: Id<"projects">) {
+async function getInitialStatusId(c: ProjectKeyAuthorizationContext, projectId: Id<"projects">) {
   const statuses = await c.env.runQuery(internal.requestStatuses.getByProjectInternal, {
     id: projectId,
   });
@@ -64,7 +57,7 @@ async function getInitialStatusId(c: RequestIntakeContext, projectId: Id<"projec
 }
 
 export async function createRequest(
-  c: RequestIntakeContext,
+  c: ProjectKeyAuthorizationContext,
   projectId: string,
   body: {
     text: string;
@@ -90,7 +83,7 @@ export async function createRequest(
   return { ok: true as const };
 }
 
-export async function deleteRequest(c: RequestIntakeContext, projectId: string, requestId: string) {
+export async function deleteRequest(c: ProjectKeyAuthorizationContext, projectId: string, requestId: string) {
   const authorization = await authorizeProjectKeyRequest(c, projectId, "admin");
   if (!authorization.ok) {
     return authorization;
@@ -105,7 +98,7 @@ export async function deleteRequest(c: RequestIntakeContext, projectId: string, 
   return { ok: true as const };
 }
 
-export async function listComments(c: RequestIntakeContext, projectId: string, requestId: string) {
+export async function listComments(c: ProjectKeyAuthorizationContext, projectId: string, requestId: string) {
   const authorization = await authorizeProjectKeyRequest(c, projectId, "read");
   if (!authorization.ok) {
     return authorization;
@@ -120,7 +113,7 @@ export async function listComments(c: RequestIntakeContext, projectId: string, r
 }
 
 export async function createComment(
-  c: RequestIntakeContext,
+  c: ProjectKeyAuthorizationContext,
   projectId: string,
   requestId: string,
   body: {
@@ -146,7 +139,7 @@ export async function createComment(
 }
 
 export async function deleteComment(
-  c: RequestIntakeContext,
+  c: ProjectKeyAuthorizationContext,
   projectId: string,
   requestId: string,
   commentId: string,
@@ -161,7 +154,7 @@ export async function deleteComment(
   });
 }
 
-export async function listUpvotes(c: RequestIntakeContext, projectId: string, clientId: string | undefined) {
+export async function listUpvotes(c: ProjectKeyAuthorizationContext, projectId: string, clientId: string | undefined) {
   const authorization = await authorizeProjectKeyRequest(c, projectId, "read");
   if (!authorization.ok) {
     return authorization;
@@ -176,7 +169,7 @@ export async function listUpvotes(c: RequestIntakeContext, projectId: string, cl
 }
 
 export async function toggleUpvote(
-  c: RequestIntakeContext,
+  c: ProjectKeyAuthorizationContext,
   projectId: string,
   requestId: string,
   clientId: string,

--- a/packages/wish-ios/Sources/WishKit/Wish.swift
+++ b/packages/wish-ios/Sources/WishKit/Wish.swift
@@ -55,9 +55,9 @@ public enum Wish {
     }
 }
 
-/// The Wish surface a ``WishView`` renders. Only requests exist today; the
-/// enum reserves room for future destinations without breaking the API.
-/// The raw value is the hosted embed's `view` query parameter.
+/// The Wish surface a ``WishView`` renders. The raw value is the hosted
+/// embed's `view` query parameter.
 public enum WishDestination: String {
     case requests
+    case changelog
 }


### PR DESCRIPTION
Closes #40

## Summary
- `WishView(.changelog)` renders the hosted project changelog inside the existing embed WebView; `WishView()` still defaults to requests.
- New key-authed `GET /api/project/:id/changelog` (read scope) — composes the feed from the project doc the key authorization already returns; published entries only.
- `getEmbedChangelog` in `embedApi.ts` — client key travels only in `x-api-key`, never the URL.
- `/embed` parses `view` (`changelog` | anything-else→`requests`) and renders a compact changelog UI reusing the existing embed primitives.
- Extracted `useEmbedResource` — one load/error/retry scaffold now backing requests, comments, and changelog loaders (net simplification; #41 will be its fourth consumer).

## Review gates passed
- thermo-nuclear code-quality review: PASS (after one fix round: composed feed from auth's project doc, deleted dead not_found branch + duplicated context types, extracted the shared loader hook)
- ponytail over-engineering review: PASS ("lean already")

## E2E verified (real dev deployment + browser)
- read-scoped key → `200` with published feed; missing key → `401 missing_api_key`; bad key → `401 invalid_api_key`
- draft entries never appear in API or embed; no-entries → compact empty state
- `view=changelog` renders entry (version + type badges, date, title, summary); no `view`/bogus `view` → requests board unchanged
- `bun test` 54/54, `tsc --noEmit` both packages, `lint:strict` clean
- `xcodebuild -scheme WishKit -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDqVoqCH3s2j1X82yqapdU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new changelog view in the embed experience, alongside the existing requests view.
  * Changelog content is now available through the app and supported on iOS destinations.

* **Bug Fixes**
  * Improved loading and retry behavior for requests, comments, and changelog content.
  * Normalized missing changelog entries to an empty list for more reliable display.

* **Style**
  * Updated embed routing to support switching between views via the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->