### PR TITLE
feat: "What's new" per-version release notes (preflight, embed view, iOS sheet)

### DIFF
--- a/apps/wish-start/src/lib/embedApi.test.ts
+++ b/apps/wish-start/src/lib/embedApi.test.ts
@@ -5,6 +5,7 @@ import {
   createEmbedRequest,
   EmbedApiError,
   getEmbedChangelog,
+  getEmbedWhatsNew,
   listEmbedRequests,
   listEmbedUpvotedRequestIds,
   toggleEmbedUpvote,
@@ -134,5 +135,27 @@ describe("embedApi", () => {
     const feed = await getEmbedChangelog(config);
 
     expect(feed.entries).toEqual([]);
+  });
+
+  it("fetches the what's-new entry with the version in the query string, sends the client key as x-api-key, never in the URL", async () => {
+    const fetchMock = mockFetch({
+      entry: { versionLabel: "2.0.0", title: "Big release", type: "feature" },
+    });
+
+    const entry = await getEmbedWhatsNew(config, "2.0.0-beta 1");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.convex.site/api/project/proj_123/whats-new?version=2.0.0-beta%201");
+    expect(url).not.toContain(config.clientKey);
+    expect(init.headers["x-api-key"]).toBe(config.clientKey);
+    expect(entry).toEqual({ versionLabel: "2.0.0", title: "Big release", type: "feature" });
+  });
+
+  it("maps a missing entry to null", async () => {
+    mockFetch({ entry: null });
+
+    const entry = await getEmbedWhatsNew(config, "9.9.9");
+
+    expect(entry).toBeNull();
   });
 });

--- a/apps/wish-start/src/lib/embedApi.ts
+++ b/apps/wish-start/src/lib/embedApi.ts
@@ -136,3 +136,11 @@ export async function getEmbedChangelog(config: EmbedApiConfig): Promise<EmbedCh
   const entries: EmbedChangelogEntry[] = Array.isArray(payload?.entries) ? payload.entries : [];
   return { project: payload.project, entries };
 }
+
+export async function getEmbedWhatsNew(
+  config: EmbedApiConfig,
+  appVersion: string,
+): Promise<EmbedChangelogEntry | null> {
+  const payload = await embedFetch(config, `/whats-new?version=${encodeURIComponent(appVersion)}`);
+  return payload?.entry ?? null;
+}

--- a/apps/wish-start/src/routeTree.gen.ts
+++ b/apps/wish-start/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as DashboardProjectProjectIdSlugRoadmapRouteImport } from './rout
 import { Route as DashboardProjectProjectIdSlugRequestsRouteImport } from './routes/dashboard.project.$projectId.$slug.requests'
 import { Route as DashboardProjectProjectIdSlugComplaintsRouteImport } from './routes/dashboard.project.$projectId.$slug.complaints'
 import { Route as DashboardProjectProjectIdSlugChangelogRouteImport } from './routes/dashboard.project.$projectId.$slug.changelog'
+import { Route as ApiProjectProjectIdWhatsNewExistsRouteImport } from './routes/api.project.$projectId.whats-new.exists'
 
 const EmbedRoute = EmbedRouteImport.update({
   id: '/embed',
@@ -113,6 +114,12 @@ const DashboardProjectProjectIdSlugChangelogRoute =
     path: '/changelog',
     getParentRoute: () => DashboardProjectProjectIdSlugRoute,
   } as any)
+const ApiProjectProjectIdWhatsNewExistsRoute =
+  ApiProjectProjectIdWhatsNewExistsRouteImport.update({
+    id: '/api/project/$projectId/whats-new/exists',
+    path: '/api/project/$projectId/whats-new/exists',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -125,6 +132,7 @@ export interface FileRoutesByFullPath {
   '/p/$projectSlug': typeof PProjectSlugRouteWithChildren
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/project/$projectId/$slug': typeof DashboardProjectProjectIdSlugRouteWithChildren
+  '/api/project/$projectId/whats-new/exists': typeof ApiProjectProjectIdWhatsNewExistsRoute
   '/dashboard/project/$projectId/$slug/changelog': typeof DashboardProjectProjectIdSlugChangelogRoute
   '/dashboard/project/$projectId/$slug/complaints': typeof DashboardProjectProjectIdSlugComplaintsRoute
   '/dashboard/project/$projectId/$slug/requests': typeof DashboardProjectProjectIdSlugRequestsRoute
@@ -141,6 +149,7 @@ export interface FileRoutesByTo {
   '/dashboard/waitlist': typeof DashboardWaitlistRoute
   '/p/$projectSlug': typeof PProjectSlugRouteWithChildren
   '/dashboard': typeof DashboardIndexRoute
+  '/api/project/$projectId/whats-new/exists': typeof ApiProjectProjectIdWhatsNewExistsRoute
   '/dashboard/project/$projectId/$slug/changelog': typeof DashboardProjectProjectIdSlugChangelogRoute
   '/dashboard/project/$projectId/$slug/complaints': typeof DashboardProjectProjectIdSlugComplaintsRoute
   '/dashboard/project/$projectId/$slug/requests': typeof DashboardProjectProjectIdSlugRequestsRoute
@@ -160,6 +169,7 @@ export interface FileRoutesById {
   '/p/$projectSlug': typeof PProjectSlugRouteWithChildren
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/project/$projectId/$slug': typeof DashboardProjectProjectIdSlugRouteWithChildren
+  '/api/project/$projectId/whats-new/exists': typeof ApiProjectProjectIdWhatsNewExistsRoute
   '/dashboard/project/$projectId/$slug/changelog': typeof DashboardProjectProjectIdSlugChangelogRoute
   '/dashboard/project/$projectId/$slug/complaints': typeof DashboardProjectProjectIdSlugComplaintsRoute
   '/dashboard/project/$projectId/$slug/requests': typeof DashboardProjectProjectIdSlugRequestsRoute
@@ -180,6 +190,7 @@ export interface FileRouteTypes {
     | '/p/$projectSlug'
     | '/dashboard/'
     | '/dashboard/project/$projectId/$slug'
+    | '/api/project/$projectId/whats-new/exists'
     | '/dashboard/project/$projectId/$slug/changelog'
     | '/dashboard/project/$projectId/$slug/complaints'
     | '/dashboard/project/$projectId/$slug/requests'
@@ -196,6 +207,7 @@ export interface FileRouteTypes {
     | '/dashboard/waitlist'
     | '/p/$projectSlug'
     | '/dashboard'
+    | '/api/project/$projectId/whats-new/exists'
     | '/dashboard/project/$projectId/$slug/changelog'
     | '/dashboard/project/$projectId/$slug/complaints'
     | '/dashboard/project/$projectId/$slug/requests'
@@ -214,6 +226,7 @@ export interface FileRouteTypes {
     | '/p/$projectSlug'
     | '/dashboard/'
     | '/dashboard/project/$projectId/$slug'
+    | '/api/project/$projectId/whats-new/exists'
     | '/dashboard/project/$projectId/$slug/changelog'
     | '/dashboard/project/$projectId/$slug/complaints'
     | '/dashboard/project/$projectId/$slug/requests'
@@ -229,6 +242,7 @@ export interface RootRouteChildren {
   EmbedRoute: typeof EmbedRoute
   ChangelogSlugRoute: typeof ChangelogSlugRoute
   PProjectSlugRoute: typeof PProjectSlugRouteWithChildren
+  ApiProjectProjectIdWhatsNewExistsRoute: typeof ApiProjectProjectIdWhatsNewExistsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -345,6 +359,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardProjectProjectIdSlugChangelogRouteImport
       parentRoute: typeof DashboardProjectProjectIdSlugRoute
     }
+    '/api/project/$projectId/whats-new/exists': {
+      id: '/api/project/$projectId/whats-new/exists'
+      path: '/api/project/$projectId/whats-new/exists'
+      fullPath: '/api/project/$projectId/whats-new/exists'
+      preLoaderRoute: typeof ApiProjectProjectIdWhatsNewExistsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -414,6 +435,8 @@ const rootRouteChildren: RootRouteChildren = {
   EmbedRoute: EmbedRoute,
   ChangelogSlugRoute: ChangelogSlugRoute,
   PProjectSlugRoute: PProjectSlugRouteWithChildren,
+  ApiProjectProjectIdWhatsNewExistsRoute:
+    ApiProjectProjectIdWhatsNewExistsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/wish-start/src/routes/api.project.$projectId.whats-new.exists.ts
+++ b/apps/wish-start/src/routes/api.project.$projectId.whats-new.exists.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { getConvexHttpBaseUrl } from "@/lib/convexHttp";
+import env from "@/env";
+
+export const Route = createFileRoute("/api/project/$projectId/whats-new/exists")({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        const url = new URL(request.url);
+        const version = url.searchParams.get("version") ?? "";
+        const upstream = `${getConvexHttpBaseUrl(env.VITE_CONVEX_URL)}/api/project/${encodeURIComponent(params.projectId)}/whats-new/exists?version=${encodeURIComponent(version)}`;
+
+        // The iOS SDK talks only to this public origin; any future native SDK API
+        // call needs its own pass-through route like this one. Forward the client's
+        // x-forwarded-for so upstream per-IP rate limiting sees real clients, not
+        // this server's egress IP.
+        const headers: Record<string, string> = {
+          "x-api-key": request.headers.get("x-api-key") ?? "",
+        };
+        const forwardedFor = request.headers.get("x-forwarded-for");
+        if (forwardedFor) {
+          headers["x-forwarded-for"] = forwardedFor;
+        }
+
+        const response = await fetch(upstream, { headers });
+
+        return new Response(await response.text(), {
+          status: response.status,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  },
+});

--- a/apps/wish-start/src/routes/embed.tsx
+++ b/apps/wish-start/src/routes/embed.tsx
@@ -14,6 +14,7 @@ import {
   createEmbedComment,
   createEmbedRequest,
   getEmbedChangelog,
+  getEmbedWhatsNew,
   listEmbedComments,
   listEmbedRequests,
   listEmbedUpvotedRequestIds,
@@ -36,7 +37,13 @@ export const Route = createFileRoute("/embed")({
     projectId: typeof search.projectId === "string" ? search.projectId : undefined,
     clientId: typeof search.clientId === "string" ? search.clientId : undefined,
     clientKey: typeof search.clientKey === "string" ? search.clientKey : undefined,
-    view: search.view === "changelog" ? ("changelog" as const) : ("requests" as const),
+    view:
+      search.view === "changelog"
+        ? ("changelog" as const)
+        : search.view === "whats-new"
+          ? ("whats-new" as const)
+          : ("requests" as const),
+    appVersion: typeof search.appVersion === "string" ? search.appVersion : undefined,
   }),
   component: EmbedPage,
 });
@@ -68,7 +75,7 @@ function useEmbedResource<T>(loader: () => Promise<T>) {
 }
 
 function EmbedPage() {
-  const { projectId, clientId, clientKey, view } = Route.useSearch();
+  const { projectId, clientId, clientKey, view, appVersion } = Route.useSearch();
   const baseUrl = getConvexHttpBaseUrl(env.VITE_CONVEX_URL);
   const config = useMemo(
     () =>
@@ -89,7 +96,26 @@ function EmbedPage() {
     );
   }
 
-  return view === "changelog" ? <EmbedChangelogApp config={config} /> : <EmbedRequestsApp config={config} />;
+  if (view === "changelog") {
+    return <EmbedChangelogApp config={config} />;
+  }
+
+  if (view === "whats-new") {
+    if (!appVersion) {
+      return (
+        <EmbedShell>
+          <EmbedNotice
+            title="Feedback is unavailable"
+            description="This embed is missing its configuration. Check the appVersion passed to Wish.configure."
+          />
+        </EmbedShell>
+      );
+    }
+
+    return <EmbedWhatsNewApp config={config} appVersion={appVersion} />;
+  }
+
+  return <EmbedRequestsApp config={config} />;
 }
 
 function EmbedRequestsApp({ config }: { config: EmbedApiConfig }) {
@@ -494,6 +520,45 @@ function EmbedChangelogEntryCard({ entry }: { entry: EmbedChangelogEntry }) {
       {entry.summary ? <p className="text-sm text-muted-foreground">{entry.summary}</p> : null}
       {entry.body ? <div className="whitespace-pre-wrap text-sm text-foreground/90">{entry.body}</div> : null}
     </article>
+  );
+}
+
+function EmbedWhatsNewApp({ config, appVersion }: { config: EmbedApiConfig; appVersion: string }) {
+  const loadEntry = useCallback(() => getEmbedWhatsNew(config, appVersion), [config, appVersion]);
+  const { data: entry, loadError, reload } = useEmbedResource(loadEntry);
+
+  if (loadError) {
+    return (
+      <EmbedShell>
+        <EmbedNotice title="Could not load updates" description={loadError}>
+          <Button type="button" variant="outline" size="sm" onClick={() => void reload()}>
+            Retry
+          </Button>
+        </EmbedNotice>
+      </EmbedShell>
+    );
+  }
+
+  if (entry === undefined) {
+    return (
+      <EmbedShell>
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6 text-muted-foreground" />
+        </div>
+      </EmbedShell>
+    );
+  }
+
+  return (
+    <EmbedShell>
+      <h1 className="text-lg font-semibold tracking-tight">What's new</h1>
+      <Separator className="my-4" />
+      {entry ? (
+        <EmbedChangelogEntryCard entry={entry} />
+      ) : (
+        <p className="text-sm text-muted-foreground">No release notes for this version.</p>
+      )}
+    </EmbedShell>
   );
 }
 

--- a/packages/convex-backend/convex/changelogEntries.ts
+++ b/packages/convex-backend/convex/changelogEntries.ts
@@ -327,3 +327,30 @@ export const listPublishedByProjectInternal = internalQuery({
     return entries.sort(sortEntriesByRecent).map((entry) => toPublicChangelogEntry(entry));
   },
 });
+
+export const getPublishedByVersionInternal = internalQuery({
+  args: {
+    projectId: v.id("projects"),
+    versionLabel: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const versionLabelNormalized = normalizeVersionLabel(args.versionLabel);
+
+    if (!versionLabelNormalized) {
+      return null;
+    }
+
+    const entry = await ctx.db
+      .query("changelogEntries")
+      .withIndex("by_project_version_label", (q) =>
+        q.eq("projectId", args.projectId).eq("versionLabelNormalized", versionLabelNormalized),
+      )
+      .unique();
+
+    if (!entry || entry.status !== "published") {
+      return null;
+    }
+
+    return toPublicChangelogEntry(entry);
+  },
+});

--- a/packages/convex-backend/convex/http.ts
+++ b/packages/convex-backend/convex/http.ts
@@ -17,7 +17,7 @@ import {
   listUpvotes,
   toggleUpvote,
 } from "./lib/requestIntake";
-import { listPublicChangelog } from "./lib/changelogIntake";
+import { getWhatsNewEntry, listPublicChangelog } from "./lib/changelogIntake";
 import { toPublicProject } from "./lib/projectPublic";
 import {
   createPublicError,
@@ -81,6 +81,42 @@ app.get("/api/project/:id/changelog", async (c) => {
     }
 
     return c.json({ project: result.project, entries: result.entries });
+  } catch (error) {
+    return publicErrorJson(c, toPublicErrorResponse(error));
+  }
+});
+
+app.get("/api/project/:id/whats-new/exists", async (c) => {
+  try {
+    const id = c.req.param("id");
+    requirePublicId(id);
+    const version = c.req.query("version");
+    requirePublicId(version);
+
+    const result = await getWhatsNewEntry(c, id, version);
+    if (!result.ok) {
+      return publicErrorJson(c, result.error);
+    }
+
+    return c.json({ hasPublishedNotes: result.entry !== null });
+  } catch (error) {
+    return publicErrorJson(c, toPublicErrorResponse(error));
+  }
+});
+
+app.get("/api/project/:id/whats-new", async (c) => {
+  try {
+    const id = c.req.param("id");
+    requirePublicId(id);
+    const version = c.req.query("version");
+    requirePublicId(version);
+
+    const result = await getWhatsNewEntry(c, id, version);
+    if (!result.ok) {
+      return publicErrorJson(c, result.error);
+    }
+
+    return c.json({ entry: result.entry });
   } catch (error) {
     return publicErrorJson(c, toPublicErrorResponse(error));
   }
@@ -201,7 +237,7 @@ function isPublicId(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function requirePublicId(value: unknown) {
+function requirePublicId(value: unknown): asserts value is string {
   if (!isPublicId(value)) {
     throw createPublicError("validation_failed");
   }

--- a/packages/convex-backend/convex/lib/changelogIntake.ts
+++ b/packages/convex-backend/convex/lib/changelogIntake.ts
@@ -21,3 +21,21 @@ export async function listPublicChangelog(c: ProjectKeyAuthorizationContext, pro
     entries,
   };
 }
+
+export async function getWhatsNewEntry(
+  c: ProjectKeyAuthorizationContext,
+  projectId: string,
+  versionLabel: string,
+) {
+  const authorization = await authorizeProjectKeyRequest(c, projectId, "read");
+  if (!authorization.ok) {
+    return authorization;
+  }
+
+  const entry = await c.env.runQuery(internal.changelogEntries.getPublishedByVersionInternal, {
+    projectId: authorization.project._id,
+    versionLabel,
+  });
+
+  return { ok: true as const, entry };
+}

--- a/packages/wish-ios/Sources/WishKit/Wish.swift
+++ b/packages/wish-ios/Sources/WishKit/Wish.swift
@@ -2,14 +2,15 @@ import Foundation
 
 /// Entry point for the Wish iOS integration.
 ///
-/// Call ``configure(appId:clientKey:externalUserId:baseURL:)`` once at app
-/// startup, then render ``WishView`` anywhere in SwiftUI.
+/// Call ``configure(appId:clientKey:externalUserId:appVersion:baseURL:)`` once
+/// at app startup, then render ``WishView`` anywhere in SwiftUI.
 public enum Wish {
     struct Configuration {
         let appId: String
         let clientKey: String
         let externalUserId: String
         let baseURL: URL
+        let appVersion: String?
     }
 
     static var configuration: Configuration?
@@ -22,20 +23,32 @@ public enum Wish {
     ///     Never use a server/admin key in an iOS app.
     ///   - externalUserId: A stable identifier for the current user of the
     ///     host app. Wish uses it to attribute requests, upvotes, and comments.
-    ///   - baseURL: The hosted Wish UI origin. Defaults to the production
-    ///     deployment.
+    ///   - appVersion: The host app's version, used to look up "What's new"
+    ///     release notes. Defaults to `CFBundleShortVersionString` from the
+    ///     host app's bundle when omitted.
+    ///   - baseURL: The single public Wish origin, serving both the hosted
+    ///     UI and the SDK's API calls. Defaults to the production deployment.
     public static func configure(
         appId: String,
         clientKey: String,
         externalUserId: String,
+        appVersion: String? = nil,
         baseURL: URL = URL(string: "https://wish-app.tymofyeyev.com")!
     ) {
         configuration = Configuration(
             appId: appId,
             clientKey: clientKey,
             externalUserId: externalUserId,
-            baseURL: baseURL
+            baseURL: baseURL,
+            appVersion: appVersion
         )
+    }
+
+    /// The app version used for "What's new" lookups: the value passed to
+    /// ``configure(appId:clientKey:externalUserId:appVersion:baseURL:)``, or
+    /// `CFBundleShortVersionString` from the host app's bundle.
+    static var currentAppVersion: String? {
+        configuration?.appVersion ?? Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     }
 
     static func embedURL(for destination: WishDestination) -> URL? {
@@ -43,14 +56,19 @@ public enum Wish {
             return nil
         }
 
-        var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false)
-        components?.path = "/embed"
-        components?.queryItems = [
+        var queryItems = [
             URLQueryItem(name: "projectId", value: configuration.appId),
             URLQueryItem(name: "clientId", value: configuration.externalUserId),
             URLQueryItem(name: "clientKey", value: configuration.clientKey),
             URLQueryItem(name: "view", value: destination.rawValue),
         ]
+        if destination == .whatsNew, let appVersion = currentAppVersion {
+            queryItems.append(URLQueryItem(name: "appVersion", value: appVersion))
+        }
+
+        var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false)
+        components?.path = "/embed"
+        components?.queryItems = queryItems
         return components?.url
     }
 }
@@ -60,4 +78,5 @@ public enum Wish {
 public enum WishDestination: String {
     case requests
     case changelog
+    case whatsNew = "whats-new"
 }

--- a/packages/wish-ios/Sources/WishKit/WishView.swift
+++ b/packages/wish-ios/Sources/WishKit/WishView.swift
@@ -3,8 +3,8 @@ import WebKit
 
 /// Renders the hosted Wish UI in a `WKWebView`.
 ///
-/// Requires ``Wish/configure(appId:clientKey:externalUserId:baseURL:)`` to
-/// have been called first; otherwise a visible configuration error is shown.
+/// Requires ``Wish/configure(appId:clientKey:externalUserId:appVersion:baseURL:)``
+/// to have been called first; otherwise a visible configuration error is shown.
 public struct WishView: View {
     private let destination: WishDestination
 

--- a/packages/wish-ios/Sources/WishKit/WishWhatsNewSheet.swift
+++ b/packages/wish-ios/Sources/WishKit/WishWhatsNewSheet.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftUI
+
+/// Presents the hosted "What's new" release notes for the current app
+/// version, at most once per version per device.
+///
+/// Requires ``Wish/configure(appId:clientKey:externalUserId:appVersion:baseURL:)``
+/// to have been called first; does nothing otherwise.
+public extension View {
+    func wishWhatsNewSheet() -> some View {
+        modifier(WishWhatsNewSheetModifier())
+    }
+}
+
+private struct WishWhatsNewSheetModifier: ViewModifier {
+    @State private var isPresented = false
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                await checkAndPresent()
+            }
+            .sheet(isPresented: $isPresented, onDismiss: markCurrentVersionSeen) {
+                WishView(.whatsNew)
+            }
+    }
+
+    private func checkAndPresent() async {
+        guard let configuration = Wish.configuration,
+              let appVersion = Wish.currentAppVersion,
+              WishWhatsNewSeenStore.seenVersion(appId: configuration.appId) != appVersion
+        else {
+            return
+        }
+
+        let hasPublishedNotes = await fetchHasPublishedNotes(configuration: configuration, appVersion: appVersion)
+        if hasPublishedNotes == true {
+            isPresented = true
+        }
+    }
+
+    private func fetchHasPublishedNotes(configuration: Wish.Configuration, appVersion: String) async -> Bool? {
+        guard var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.path = "/api/project/\(configuration.appId)/whats-new/exists"
+        components.queryItems = [URLQueryItem(name: "version", value: appVersion)]
+
+        guard let url = components.url else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(configuration.clientKey, forHTTPHeaderField: "x-api-key")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return nil
+            }
+            let payload = try JSONDecoder().decode(WhatsNewExistsResponse.self, from: data)
+            return payload.hasPublishedNotes
+        } catch {
+            return nil
+        }
+    }
+
+    private func markCurrentVersionSeen() {
+        guard let configuration = Wish.configuration, let appVersion = Wish.currentAppVersion else {
+            return
+        }
+        WishWhatsNewSeenStore.markSeen(appId: configuration.appId, version: appVersion)
+    }
+}
+
+private struct WhatsNewExistsResponse: Decodable {
+    let hasPublishedNotes: Bool
+}
+
+/// Local-only record of the last app version a device has seen "What's new"
+/// notes for, scoped by project so multiple Wish-enabled apps don't collide.
+private enum WishWhatsNewSeenStore {
+    private static func key(appId: String) -> String {
+        "wish.whatsNew.seenVersion.\(appId)"
+    }
+
+    static func seenVersion(appId: String) -> String? {
+        UserDefaults.standard.string(forKey: key(appId: appId))
+    }
+
+    static func markSeen(appId: String, version: String) {
+        UserDefaults.standard.set(version, forKey: key(appId: appId))
+    }
+}


### PR DESCRIPTION
Closes #41

**Stacked on #43** (`feat/ios-embed-changelog`) — merge that first; this PR's base is that branch.

## Summary
- Key-authed (read scope) `GET /api/project/:id/whats-new/exists?version=X` → `{ hasPublishedNotes }` and `GET /api/project/:id/whats-new?version=X` → `{ entry | null }`. Exact normalized `versionLabel` match (reuses the existing normalizer + `by_project_version_label` unique index), published entries only, blank/missing version → `validation_failed`.
- `/embed?view=whats-new&appVersion=X` renders the single release note (reuses `useEmbedResource` + the changelog entry card from #43); missing `appVersion` → config-error notice; no notes → compact empty state.
- Swift: `Wish.configure(appVersion:)` (defaults to `CFBundleShortVersionString` at read time), `WishDestination.whatsNew`, and `.wishWhatsNewSheet()` — preflights, presents the hosted sheet at most once per version per device, marks seen in `UserDefaults` **only when the user dismisses an actually-shown sheet**; any preflight failure is silent and retries naturally on next appear.

## Design decision to sanity-check
The SDK's native preflight goes through a **pass-through server route on the wish-start origin** (`api.project.$projectId.whats-new.exists.ts`) rather than adding an `apiBaseURL` knob to `Wish.configure`. Rationale: the SDK keeps exactly one configured URL, no production Convex URL gets baked into a shipped binary, and the Convex origin stays a server-side env concern. The proxy forwards `x-api-key` and `x-forwarded-for` verbatim (the latter so upstream per-IP rate limiting still sees real clients). Veto if you'd rather have the explicit knob.

## Review gates passed
- thermo-nuclear review: FAIL→PASS across one fix round (the original preflight hit the UI origin where no API existed — would have been silently dead in production; plus validation-helper reuse, stale DocC links, config-error state). Reviewer explicitly accepted the BFF facade over its own `apiBaseURL` suggestion.
- ponytail over-engineering review: PASS ("lean already").

## E2E verified (real dev deployment + browser + curl)
- Convex origin: published → `{hasPublishedNotes:true}` / draft & unknown → `false` / no version → `400 validation_failed` / feed returns entry or `null`; case-normalized match (`V0.2.0` → true)
- SDK-facing proxy on the app origin: verbatim pass-through incl. `401 missing/invalid_api_key`, `400`, and success — this is the exact URL shape `wishWhatsNewSheet()` calls
- Embed at phone viewport: entry card for published version, empty notice for unknown version, draft never leaks, missing `appVersion` → config notice
- `bun test` 56/56, `tsc` both packages, `lint:strict` clean, `xcodebuild -scheme WishKit -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED (0 warnings)
- Not covered by automation: the sheet's on-device present/dismiss cycle (no test target or host app in the package) — state machine was review-verified instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDqVoqCH3s2j1X82yqapdU