### PR TITLE
feat: add bulk request table actions

### DIFF
--- a/apps/wish-start/src/components/Request/RequestBulkActions.tsx
+++ b/apps/wish-start/src/components/Request/RequestBulkActions.tsx
@@ -1,0 +1,120 @@
+import { Button } from "@components/ui/button";
+import type { Doc, Id } from "@wish/convex-backend/data-model";
+import { Trash2, X } from "lucide-react";
+import { useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function RequestBulkActions({
+  count,
+  isPending,
+  kind,
+  onClear,
+  onDelete,
+  onStatusChange,
+  statuses,
+}: {
+  count: number;
+  isPending: boolean;
+  kind: "request" | "complaint";
+  onClear: () => void;
+  onDelete: () => Promise<boolean>;
+  onStatusChange: (status: Id<"requestStatuses">) => Promise<void>;
+  statuses: Doc<"requestStatuses">[];
+}) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const label = kind === "complaint" ? "complaint" : "request";
+
+  const handleDelete = async () => {
+    if (await onDelete()) setIsDeleteOpen(false);
+  };
+
+  return (
+    <div
+      aria-live="polite"
+      className="flex flex-wrap items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 p-2 dark:border-orange-900 dark:bg-orange-950/30"
+    >
+      <span className="mr-auto px-1 text-sm font-medium">
+        {count} {label}
+        {count === 1 ? "" : "s"} selected
+      </span>
+
+      <Select
+        disabled={isPending}
+        onValueChange={(statusId) => {
+          const status = statuses.find((item) => item._id === statusId);
+          if (status) void onStatusChange(status._id);
+        }}
+        value=""
+      >
+        <SelectTrigger size="sm" aria-label="Change status">
+          <SelectValue placeholder="Change status" />
+        </SelectTrigger>
+        <SelectContent>
+          {statuses.map((status) => (
+            <SelectItem key={status._id} value={status._id}>
+              {status.displayName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <AlertDialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
+        <AlertDialogTrigger asChild>
+          <Button type="button" size="sm" variant="destructive" disabled={isPending}>
+            <Trash2 />
+            Delete
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {count} {label}
+              {count === 1 ? "" : "s"}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the selected {label}
+              {count === 1 ? "" : "s"}, including their comments and upvotes. This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+              disabled={isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
+            >
+              {isPending ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Button type="button" size="sm" variant="ghost" disabled={isPending} onClick={onClear}>
+        <X />
+        Clear selection
+      </Button>
+    </div>
+  );
+}

--- a/apps/wish-start/src/components/Request/RequestBulkActions.tsx
+++ b/apps/wish-start/src/components/Request/RequestBulkActions.tsx
@@ -40,8 +40,6 @@ export function RequestBulkActions({
   statuses: Doc<"requestStatuses">[];
 }) {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const label = kind === "complaint" ? "complaint" : "request";
-
   const handleDelete = async () => {
     if (await onDelete()) setIsDeleteOpen(false);
   };
@@ -52,7 +50,7 @@ export function RequestBulkActions({
       className="flex flex-wrap items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 p-2 dark:border-orange-900 dark:bg-orange-950/30"
     >
       <span className="mr-auto px-1 text-sm font-medium">
-        {count} {label}
+        {count} {kind}
         {count === 1 ? "" : "s"} selected
       </span>
 
@@ -86,11 +84,11 @@ export function RequestBulkActions({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Delete {count} {label}
+              Delete {count} {kind}
               {count === 1 ? "" : "s"}?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              This permanently deletes the selected {label}
+              This permanently deletes the selected {kind}
               {count === 1 ? "" : "s"}, including their comments and upvotes. This action cannot be
               undone.
             </AlertDialogDescription>

--- a/apps/wish-start/src/components/Request/RequestBulkActions.tsx
+++ b/apps/wish-start/src/components/Request/RequestBulkActions.tsx
@@ -47,7 +47,7 @@ export function RequestBulkActions({
   return (
     <div
       aria-live="polite"
-      className="flex flex-wrap items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 p-2 dark:border-orange-900 dark:bg-orange-950/30"
+      className="fixed bottom-4 left-1/2 z-40 flex w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 animate-in flex-wrap items-center gap-2 rounded-xl border border-orange-200 bg-orange-50/95 p-2 shadow-xl fade-in-0 slide-in-from-bottom-2 duration-150 motion-reduce:animate-none dark:border-orange-900 dark:bg-orange-950/95"
     >
       <span className="mr-auto px-1 text-sm font-medium">
         {count} {kind}

--- a/apps/wish-start/src/components/Request/RequestTable.tsx
+++ b/apps/wish-start/src/components/Request/RequestTable.tsx
@@ -3,9 +3,12 @@ import useStatuses from "#/hooks/useStatuses";
 import { trimTo } from "#/lib/text.ts";
 import SortButton from "@components/atoms/SortButton";
 import { Checkbox } from "@components/ui/checkbox";
-import { type ColumnDef } from "@tanstack/react-table";
+import { type ColumnDef, type RowSelectionState } from "@tanstack/react-table";
+import { api } from "@wish/convex-backend/api";
 import type { Doc, Id } from "@wish/convex-backend/data-model";
-import { useMemo } from "react";
+import { useMutation } from "convex/react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import type { Filter } from "@/lib/requestBoard/buildFilters";
 
@@ -13,6 +16,7 @@ import EntityTable from "../molecules/EntityTable";
 import StatusChip from "../Status/StatusChip";
 
 import RequestDetailView from "./DetailView/RequestDeatailView";
+import { RequestBulkActions } from "./RequestBulkActions";
 import RequestsEmpty from "./RequestsEmpty";
 
 interface RequestTableProps {
@@ -29,7 +33,50 @@ type RequestEntry = {
 
 const RequestTable = ({ projectId, kind }: RequestTableProps) => {
   const { value: requests, byId, byStatus, isPending } = useRequests(projectId, kind);
-  const { byId: statusesById } = useStatuses(projectId);
+  const { value: statuses, byId: statusesById } = useStatuses(projectId);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [isBulkMutationPending, setIsBulkMutationPending] = useState(false);
+  const updateStatuses = useMutation(api.requests.updateStatuses);
+  const deleteRequests = useMutation(api.requests.deleteRequests);
+  const selectedIds = Object.keys(rowSelection) as Id<"requests">[];
+
+  const handleBulkStatusChange = async (status: Id<"requestStatuses">) => {
+    if (isBulkMutationPending || selectedIds.length === 0) return;
+
+    try {
+      setIsBulkMutationPending(true);
+      await updateStatuses({ ids: selectedIds, status });
+      setRowSelection({});
+      toast.success(
+        `${selectedIds.length} ${kind === "complaint" ? "complaints" : "requests"} updated`,
+      );
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to update the selected items");
+    } finally {
+      setIsBulkMutationPending(false);
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    if (isBulkMutationPending || selectedIds.length === 0) return false;
+
+    try {
+      setIsBulkMutationPending(true);
+      await deleteRequests({ ids: selectedIds });
+      setRowSelection({});
+      toast.success(
+        `${selectedIds.length} ${kind === "complaint" ? "complaints" : "requests"} deleted`,
+      );
+      return true;
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to delete the selected items");
+      return false;
+    } finally {
+      setIsBulkMutationPending(false);
+    }
+  };
 
   const mappedRequests: RequestEntry[] = useMemo(
     () =>
@@ -58,14 +105,21 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
         id: "select",
         header: ({ table }) => (
           <Checkbox
-            checked={table.getIsAllRowsSelected()}
-            onCheckedChange={(v) => table.toggleAllRowsSelected(!!v)}
+            aria-label="Select current page"
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && "indeterminate")
+            }
+            disabled={isBulkMutationPending}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
           />
         ),
         cell: ({ row }) => (
           <Checkbox
+            aria-label={`Select ${kind === "complaint" ? "complaint" : "request"}`}
             checked={row.getIsSelected()}
-            onCheckedChange={(v) => row.toggleSelected(!!v)}
+            disabled={isBulkMutationPending}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
           />
         ),
       },
@@ -125,7 +179,7 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
         },
       },
     ],
-    [byId, kind],
+    [byId, isBulkMutationPending, kind],
   );
 
   // empty
@@ -134,13 +188,27 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
 
   return (
     <div className="mt-1 flex w-full flex-col gap-4">
+      {selectedIds.length > 0 && (
+        <RequestBulkActions
+          count={selectedIds.length}
+          isPending={isBulkMutationPending}
+          kind={kind ?? "request"}
+          onClear={() => setRowSelection({})}
+          onDelete={handleBulkDelete}
+          onStatusChange={handleBulkStatusChange}
+          statuses={statuses ?? []}
+        />
+      )}
       <EntityTable
         data={mappedRequests}
         columns={columns}
+        getRowId={(row) => row._id}
         initialSorting={[{ id: "title", desc: true }]}
         getSearchText={(row) => [row.title, row.description, row.status?.name]}
         getFilterText={(row) => [row.status?.name]}
         filters={filters}
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
       />
     </div>
   );

--- a/apps/wish-start/src/components/Request/RequestTable.tsx
+++ b/apps/wish-start/src/components/Request/RequestTable.tsx
@@ -7,7 +7,7 @@ import { type ColumnDef, type RowSelectionState } from "@tanstack/react-table";
 import { api } from "@wish/convex-backend/api";
 import type { Doc, Id } from "@wish/convex-backend/data-model";
 import { useMutation } from "convex/react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { Filter } from "@/lib/requestBoard/buildFilters";
@@ -36,14 +36,18 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
   const { value: statuses, byId: statusesById } = useStatuses(projectId);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isBulkMutationPending, setIsBulkMutationPending] = useState(false);
+  const bulkMutationInFlight = useRef(false);
   const updateStatuses = useMutation(api.requests.updateStatuses);
   const deleteRequests = useMutation(api.requests.deleteRequests);
-  const selectedIds = Object.keys(rowSelection) as Id<"requests">[];
+  const selectedIds = (requests ?? [])
+    .filter((request) => rowSelection[request._id])
+    .map((request) => request._id);
 
   const handleBulkStatusChange = async (status: Id<"requestStatuses">) => {
-    if (isBulkMutationPending || selectedIds.length === 0) return;
+    if (bulkMutationInFlight.current || selectedIds.length === 0) return;
 
     try {
+      bulkMutationInFlight.current = true;
       setIsBulkMutationPending(true);
       await updateStatuses({ ids: selectedIds, status });
       setRowSelection({});
@@ -54,14 +58,16 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
       console.error(error);
       toast.error("Unable to update the selected items");
     } finally {
+      bulkMutationInFlight.current = false;
       setIsBulkMutationPending(false);
     }
   };
 
   const handleBulkDelete = async () => {
-    if (isBulkMutationPending || selectedIds.length === 0) return false;
+    if (bulkMutationInFlight.current || selectedIds.length === 0) return false;
 
     try {
+      bulkMutationInFlight.current = true;
       setIsBulkMutationPending(true);
       await deleteRequests({ ids: selectedIds });
       setRowSelection({});
@@ -74,6 +80,7 @@ const RequestTable = ({ projectId, kind }: RequestTableProps) => {
       toast.error("Unable to delete the selected items");
       return false;
     } finally {
+      bulkMutationInFlight.current = false;
       setIsBulkMutationPending(false);
     }
   };

--- a/apps/wish-start/src/components/dashboard/DashboardBoard.tsx
+++ b/apps/wish-start/src/components/dashboard/DashboardBoard.tsx
@@ -23,7 +23,7 @@ export default function DashboardBoard({ projectId, boardType, kind }: Props) {
       {boardType === "kanban" ? (
         <RequestKanban projectId={project._id} kind={kind} />
       ) : (
-        <RequestTable projectId={projectId} kind={kind} />
+        <RequestTable key={`${projectId}:${kind ?? "request"}`} projectId={projectId} kind={kind} />
       )}
     </div>
     // </div>

--- a/apps/wish-start/src/components/molecules/EntityTable.test.tsx
+++ b/apps/wish-start/src/components/molecules/EntityTable.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { Checkbox } from "@/components/ui/checkbox";
+
+import EntityTable from "./EntityTable";
+
+const data = Array.from({ length: 21 }, (_, index) => ({
+  id: `request-${index + 1}`,
+  title: `Request ${index + 1}`,
+}));
+
+const columns: ColumnDef<(typeof data)[number]>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        aria-label="Select current page"
+        checked={
+          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        aria-label={`Select ${row.original.title}`}
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+      />
+    ),
+  },
+  { accessorKey: "title", header: "Title" },
+];
+
+function SelectionTable() {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  return (
+    <>
+      <output aria-label="Selected count">{Object.keys(rowSelection).length}</output>
+      <EntityTable
+        columns={columns}
+        data={data}
+        filters={[]}
+        getRowId={(row) => row.id}
+        getSearchText={(row) => [row.title]}
+        initialSorting={[]}
+        onRowSelectionChange={setRowSelection}
+        rowSelection={rowSelection}
+      />
+    </>
+  );
+}
+
+describe("EntityTable row selection", () => {
+  it("selects the current page and preserves stable selections across pages", () => {
+    render(<SelectionTable />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Request 1" }));
+    expect(
+      screen.getByRole("checkbox", { name: "Select current page" }).getAttribute("aria-checked"),
+    ).toBe("mixed");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select current page" }));
+    expect(screen.getByLabelText("Selected count").textContent).toBe("20");
+
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(
+      screen.getByRole("checkbox", { name: "Select current page" }).getAttribute("aria-checked"),
+    ).toBe("false");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Request 21" }));
+    expect(screen.getByLabelText("Selected count").textContent).toBe("21");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select current page" }));
+    expect(screen.getByLabelText("Selected count").textContent).toBe("20");
+  });
+});

--- a/apps/wish-start/src/components/molecules/EntityTable.tsx
+++ b/apps/wish-start/src/components/molecules/EntityTable.tsx
@@ -24,6 +24,8 @@ import {
   getSortedRowModel,
   useReactTable,
   type ColumnDef,
+  type OnChangeFn,
+  type RowSelectionState,
   type SortingState,
 } from "@tanstack/react-table";
 import { TableProperties } from "lucide-react";
@@ -41,7 +43,10 @@ interface EntityTableProps<T> extends Pick<ComponentProps<typeof FilterList>, "f
   initialSorting: SortingState;
   getSearchText: FieldsFN<T>;
   getFilterText?: FieldsFN<T>;
+  getRowId?: (row: T) => string;
   isLoading?: boolean;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  rowSelection?: RowSelectionState;
 }
 
 const filterData = <T,>(row: T, query: string, fieldsFn?: FieldsFN<T>): boolean => {
@@ -56,7 +61,10 @@ const EntityTable = <T,>({
   isLoading,
   getSearchText,
   getFilterText,
+  getRowId,
   initialSorting,
+  onRowSelectionChange,
+  rowSelection,
   filters,
 }: EntityTableProps<T>) => {
   const [sorting, setSorting] = useState<SortingState>(initialSorting);
@@ -78,9 +86,11 @@ const EntityTable = <T,>({
   const table = useReactTable({
     data: filteredData,
     columns,
-    state: { sorting, pagination },
+    state: { sorting, pagination, rowSelection },
     onSortingChange: setSorting,
     onPaginationChange: setPagination,
+    onRowSelectionChange,
+    getRowId,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/wish-start/src/components/ui/alert-dialog.tsx
+++ b/apps/wish-start/src/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 origin-center gap-4 rounded-xl border bg-background p-6 shadow-lg duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg",
         className
       )}
       {...props}

--- a/apps/wish-start/src/lib/requestBoard/boardState.ts
+++ b/apps/wish-start/src/lib/requestBoard/boardState.ts
@@ -11,6 +11,13 @@ export function groupRequestsByStatus(requests?: Doc<"requests">[]) {
   }, {});
 }
 
+export function getRequestsForStatus(
+  requestsByStatus: Record<string, Doc<"requests">[]>,
+  statusId: Id<"requestStatuses">,
+) {
+  return requestsByStatus[statusId] ?? [];
+}
+
 export function toUpvotedRequestSet(viewerUpvotes?: Id<"requests">[]) {
   return new Set(viewerUpvotes ?? []);
 }

--- a/apps/wish-start/vitest.config.ts
+++ b/apps/wish-start/vitest.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "vite-plus/test/config";
 
 export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/packages/convex-backend/convex/requests.test.ts
+++ b/packages/convex-backend/convex/requests.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import type { Doc, Id } from "./_generated/dataModel";
-import { deleteRequestsInBulk, getBulkRequests, updateRequestStatuses } from "./requests";
+import { deleteOwnedRequests, getBulkRequests, updateRequestStatuses } from "./requests";
 
 const projectId = "project-1" as Id<"projects">;
 
@@ -119,8 +119,36 @@ describe("bulk request validation", () => {
         ids: [first._id, otherProject._id],
         status: statusId,
       }),
-    ).rejects.toThrow("Failed to update requests");
+    ).rejects.toThrow("same project");
     expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("performs no status writes for a non-owner or foreign Status", async () => {
+    const first = request("request-1");
+    const statusId = "status-2" as Id<"requestStatuses">;
+    const nonOwner = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [projectId]: { _id: projectId, user: "user-2" },
+      [statusId]: { _id: statusId, project: projectId },
+    });
+
+    await expect(
+      updateRequestStatuses(nonOwner.ctx, { ids: [first._id], status: statusId }),
+    ).rejects.toThrow("Not authorized");
+    expect(nonOwner.patch).not.toHaveBeenCalled();
+
+    const foreignStatus = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [projectId]: { _id: projectId, user: "user-1" },
+      [statusId]: { _id: statusId, project: "project-2" },
+    });
+
+    await expect(
+      updateRequestStatuses(foreignStatus.ctx, { ids: [first._id], status: statusId }),
+    ).rejects.toThrow("Status does not belong");
+    expect(foreignStatus.patch).not.toHaveBeenCalled();
   });
 
   it("deletes every selected Request and its dependent records", async () => {
@@ -135,11 +163,29 @@ describe("bulk request validation", () => {
       comment: { _id: "comment-1", requestId: first._id, message: "Comment" },
     });
 
-    await deleteRequestsInBulk(ctx, { ids: [first._id, second._id] });
+    await deleteOwnedRequests(ctx, [first._id, second._id]);
 
     expect(remove).toHaveBeenCalledWith("upvote-1");
     expect(remove).toHaveBeenCalledWith("comment-1");
     expect(remove).toHaveBeenCalledWith(first._id);
     expect(remove).toHaveBeenCalledWith(second._id);
+  });
+
+  it("performs no deletes when ownership or request validation fails", async () => {
+    const first = request("request-1");
+    const nonOwner = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [projectId]: { _id: projectId, user: "user-2" },
+    });
+
+    await expect(deleteOwnedRequests(nonOwner.ctx, [first._id])).rejects.toThrow("Not authorized");
+    expect(nonOwner.remove).not.toHaveBeenCalled();
+
+    const missingRequest = mutationContext({ user: { _id: "user-1" } });
+    await expect(
+      deleteOwnedRequests(missingRequest.ctx, ["missing" as Id<"requests">]),
+    ).rejects.toThrow("Request not found");
+    expect(missingRequest.remove).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex-backend/convex/requests.test.ts
+++ b/packages/convex-backend/convex/requests.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import { deleteRequestsInBulk, getBulkRequests, updateRequestStatuses } from "./requests";
+
+const projectId = "project-1" as Id<"projects">;
+
+function request(id: string, project = projectId) {
+  return { _id: id, project } as Doc<"requests">;
+}
+
+function context(requests: Doc<"requests">[]) {
+  return {
+    db: {
+      get: async (id: Id<"requests">) => requests.find((item) => item._id === id) ?? null,
+    },
+  } as never;
+}
+
+function mutationContext(records: Record<string, unknown>) {
+  const patch = vi.fn(async () => undefined);
+  const remove = vi.fn(async () => undefined);
+
+  return {
+    ctx: {
+      auth: {
+        getUserIdentity: async () => ({ tokenIdentifier: "token" }),
+      },
+      db: {
+        delete: remove,
+        get: async (id: string) => records[id] ?? null,
+        patch,
+        query: (table: string) => ({
+          withIndex: (
+            _index: string,
+            build: (query: { eq: (_field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            let indexedValue: unknown;
+            build({
+              eq: (_field, value) => {
+                indexedValue = value;
+                return {};
+              },
+            });
+
+            return {
+              collect: async () =>
+                Object.values(records).filter((record) => {
+                  if (!record || typeof record !== "object" || !("requestId" in record)) {
+                    return false;
+                  }
+                  return record.requestId === indexedValue;
+                }),
+              unique: async () => (table === "users" ? records.user : null),
+            };
+          },
+        }),
+      },
+    } as never,
+    patch,
+    remove,
+  };
+}
+
+describe("bulk request validation", () => {
+  it("returns unique requests from one Project Board", async () => {
+    const first = request("request-1");
+    const second = request("request-2");
+
+    await expect(
+      getBulkRequests(context([first, second]), [first._id, second._id, first._id]),
+    ).resolves.toEqual([first, second]);
+  });
+
+  it("rejects missing and cross-project requests before mutation work begins", async () => {
+    const first = request("request-1");
+    const otherProject = request("request-2", "project-2" as Id<"projects">);
+
+    await expect(getBulkRequests(context([first]), [])).rejects.toThrow("Select at least one");
+    await expect(
+      getBulkRequests(context([first]), [first._id, "missing" as Id<"requests">]),
+    ).rejects.toThrow("Request not found");
+    await expect(
+      getBulkRequests(context([first, otherProject]), [first._id, otherProject._id]),
+    ).rejects.toThrow("same project");
+  });
+
+  it("updates every selected Request after validating the Project Board and Status", async () => {
+    const first = request("request-1");
+    const second = request("request-2");
+    const statusId = "status-2" as Id<"requestStatuses">;
+    const { ctx, patch } = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [second._id]: second,
+      [projectId]: { _id: projectId, user: "user-1" },
+      [statusId]: { _id: statusId, project: projectId },
+    });
+
+    await updateRequestStatuses(ctx, { ids: [first._id, second._id], status: statusId });
+
+    expect(patch).toHaveBeenCalledTimes(2);
+    expect(patch).toHaveBeenCalledWith(first._id, { status: statusId });
+    expect(patch).toHaveBeenCalledWith(second._id, { status: statusId });
+  });
+
+  it("performs no status writes when bulk validation fails", async () => {
+    const first = request("request-1");
+    const otherProject = request("request-2", "project-2" as Id<"projects">);
+    const statusId = "status-2" as Id<"requestStatuses">;
+    const { ctx, patch } = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [otherProject._id]: otherProject,
+    });
+
+    await expect(
+      updateRequestStatuses(ctx, {
+        ids: [first._id, otherProject._id],
+        status: statusId,
+      }),
+    ).rejects.toThrow("Failed to update requests");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("deletes every selected Request and its dependent records", async () => {
+    const first = request("request-1");
+    const second = request("request-2");
+    const { ctx, remove } = mutationContext({
+      user: { _id: "user-1" },
+      [first._id]: first,
+      [second._id]: second,
+      [projectId]: { _id: projectId, user: "user-1" },
+      upvote: { _id: "upvote-1", requestId: first._id, user: "user-2" },
+      comment: { _id: "comment-1", requestId: first._id, message: "Comment" },
+    });
+
+    await deleteRequestsInBulk(ctx, { ids: [first._id, second._id] });
+
+    expect(remove).toHaveBeenCalledWith("upvote-1");
+    expect(remove).toHaveBeenCalledWith("comment-1");
+    expect(remove).toHaveBeenCalledWith(first._id);
+    expect(remove).toHaveBeenCalledWith(second._id);
+  });
+});

--- a/packages/convex-backend/convex/requests.ts
+++ b/packages/convex-backend/convex/requests.ts
@@ -34,12 +34,8 @@ export async function getBulkRequests(
   return existingRequests;
 }
 
-async function deleteRequestCascade(ctx: MutationCtx, id: Id<"requests">) {
-  const request = await ctx.db.get(id);
-  if (!request) {
-    throw new Error("Request not found");
-  }
-
+async function deleteRequestCascade(ctx: MutationCtx, request: Doc<"requests">) {
+  const id = request._id;
   const upvotes = await ctx.db
     .query("requestUpvotes")
     .withIndex("by_request", (q) => q.eq("requestId", id))
@@ -52,8 +48,6 @@ async function deleteRequestCascade(ctx: MutationCtx, id: Id<"requests">) {
   await Promise.all(upvotes.map((upvote) => ctx.db.delete(upvote._id)));
   await Promise.all(comments.map((comment) => ctx.db.delete(comment._id)));
   await ctx.db.delete(id);
-
-  return request;
 }
 
 export const getByProject = query({
@@ -210,37 +204,21 @@ export const updateStatus = mutation({
     id: v.id("requests"),
     status: v.id("requestStatuses"),
   },
-  handler: async (ctx, args) => {
-    const user = await getCurrentUser(ctx);
-    const request = await ctx.db.get(args.id);
-    if (!request) {
-      throw new Error("Request not found");
-    }
-    await assertProjectOwner(ctx, request.project, user._id);
-    await assertStatusBelongsToProject(ctx, args.status, request.project);
-
-    await ctx.db.patch(args.id, { status: args.status });
-  },
+  handler: async (ctx, args) =>
+    await updateRequestStatuses(ctx, { ids: [args.id], status: args.status }),
 });
 
 export async function updateRequestStatuses(
   ctx: MutationCtx,
   args: { ids: Id<"requests">[]; status: Id<"requestStatuses"> },
 ) {
-  try {
-    const user = await getCurrentUser(ctx);
-    const requests = await getBulkRequests(ctx, args.ids);
-    const projectId = requests[0].project;
+  const user = await getCurrentUser(ctx);
+  const requests = await getBulkRequests(ctx, args.ids);
+  const projectId = requests[0].project;
 
-    await assertProjectOwner(ctx, projectId, user._id);
-    await assertStatusBelongsToProject(ctx, args.status, projectId);
-    await Promise.all(
-      requests.map((request) => ctx.db.patch(request._id, { status: args.status })),
-    );
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to update requests");
-  }
+  await assertProjectOwner(ctx, projectId, user._id);
+  await assertStatusBelongsToProject(ctx, args.status, projectId);
+  await Promise.all(requests.map((request) => ctx.db.patch(request._id, { status: args.status })));
 }
 
 export const updateStatuses = mutation({
@@ -248,18 +226,21 @@ export const updateStatuses = mutation({
     ids: v.array(v.id("requests")),
     status: v.id("requestStatuses"),
   },
-  handler: updateRequestStatuses,
+  handler: async (ctx, args) => {
+    try {
+      await updateRequestStatuses(ctx, args);
+    } catch (error) {
+      console.error(error);
+      throw new Error("Failed to update requests");
+    }
+  },
 });
 
 export const deleteRequest = mutation({
   args: { id: v.id("requests") },
   handler: async (ctx, args) => {
     try {
-      const user = await getCurrentUser(ctx);
-      const request = await ctx.db.get(args.id);
-      if (!request) throw new Error("Request not found");
-      await assertProjectOwner(ctx, request.project, user._id);
-      await deleteRequestCascade(ctx, args.id);
+      await deleteOwnedRequests(ctx, [args.id]);
     } catch (error) {
       console.error(error);
       throw new Error("Failed to delete request");
@@ -267,24 +248,24 @@ export const deleteRequest = mutation({
   },
 });
 
-export async function deleteRequestsInBulk(ctx: MutationCtx, args: { ids: Id<"requests">[] }) {
-  try {
-    const user = await getCurrentUser(ctx);
-    const requests = await getBulkRequests(ctx, args.ids);
+export async function deleteOwnedRequests(ctx: MutationCtx, ids: Id<"requests">[]) {
+  const user = await getCurrentUser(ctx);
+  const requests = await getBulkRequests(ctx, ids);
 
-    await assertProjectOwner(ctx, requests[0].project, user._id);
-    for (const request of requests) {
-      await deleteRequestCascade(ctx, request._id);
-    }
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to delete requests");
-  }
+  await assertProjectOwner(ctx, requests[0].project, user._id);
+  await Promise.all(requests.map((request) => deleteRequestCascade(ctx, request)));
 }
 
 export const deleteRequests = mutation({
   args: { ids: v.array(v.id("requests")) },
-  handler: deleteRequestsInBulk,
+  handler: async (ctx, args) => {
+    try {
+      await deleteOwnedRequests(ctx, args.ids);
+    } catch (error) {
+      console.error(error);
+      throw new Error("Failed to delete requests");
+    }
+  },
 });
 
 export const deleteRequestByApiKeyInternal = internalMutation({
@@ -299,7 +280,7 @@ export const deleteRequestByApiKeyInternal = internalMutation({
         throw new Error("Request does not belong to project");
       }
 
-      await deleteRequestCascade(ctx, args.id);
+      await deleteRequestCascade(ctx, request);
     } catch (error) {
       console.error(error);
       throw new Error("Failed to delete request");

--- a/packages/convex-backend/convex/requests.ts
+++ b/packages/convex-backend/convex/requests.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
@@ -10,6 +10,29 @@ import { assertStatusBelongsToProject } from "./lib/requestStatusWorkflow";
 import { emitNotificationEvent } from "./notificationEvents";
 
 const requestKindValidator = v.union(v.literal("request"), v.literal("complaint"));
+
+export async function getBulkRequests(
+  ctx: Pick<MutationCtx, "db">,
+  ids: Id<"requests">[],
+): Promise<Doc<"requests">[]> {
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) {
+    throw new Error("Select at least one request");
+  }
+
+  const requests = await Promise.all(uniqueIds.map((id) => ctx.db.get(id)));
+  if (requests.some((request) => !request)) {
+    throw new Error("Request not found");
+  }
+
+  const existingRequests = requests as Doc<"requests">[];
+  const projectId = existingRequests[0].project;
+  if (existingRequests.some((request) => request.project !== projectId)) {
+    throw new Error("Requests must belong to the same project");
+  }
+
+  return existingRequests;
+}
 
 async function deleteRequestCascade(ctx: MutationCtx, id: Id<"requests">) {
   const request = await ctx.db.get(id);
@@ -200,6 +223,34 @@ export const updateStatus = mutation({
   },
 });
 
+export async function updateRequestStatuses(
+  ctx: MutationCtx,
+  args: { ids: Id<"requests">[]; status: Id<"requestStatuses"> },
+) {
+  try {
+    const user = await getCurrentUser(ctx);
+    const requests = await getBulkRequests(ctx, args.ids);
+    const projectId = requests[0].project;
+
+    await assertProjectOwner(ctx, projectId, user._id);
+    await assertStatusBelongsToProject(ctx, args.status, projectId);
+    await Promise.all(
+      requests.map((request) => ctx.db.patch(request._id, { status: args.status })),
+    );
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to update requests");
+  }
+}
+
+export const updateStatuses = mutation({
+  args: {
+    ids: v.array(v.id("requests")),
+    status: v.id("requestStatuses"),
+  },
+  handler: updateRequestStatuses,
+});
+
 export const deleteRequest = mutation({
   args: { id: v.id("requests") },
   handler: async (ctx, args) => {
@@ -214,6 +265,26 @@ export const deleteRequest = mutation({
       throw new Error("Failed to delete request");
     }
   },
+});
+
+export async function deleteRequestsInBulk(ctx: MutationCtx, args: { ids: Id<"requests">[] }) {
+  try {
+    const user = await getCurrentUser(ctx);
+    const requests = await getBulkRequests(ctx, args.ids);
+
+    await assertProjectOwner(ctx, requests[0].project, user._id);
+    for (const request of requests) {
+      await deleteRequestCascade(ctx, request._id);
+    }
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to delete requests");
+  }
+}
+
+export const deleteRequests = mutation({
+  args: { ids: v.array(v.id("requests")) },
+  handler: deleteRequestsInBulk,
 });
 
 export const deleteRequestByApiKeyInternal = internalMutation({


### PR DESCRIPTION
Closes #61

## Summary

- add current-page selection with stable Request IDs and cross-page accumulation
- add contextual status-change, delete-confirmation, and clear-selection controls for Requests and Complaints
- add atomic Convex bulk status and cascaded delete mutations with ownership, same-project, and Status validation
- restore the pre-existing missing `getRequestsForStatus` helper so the baseline suite is clean

## Checks

- `bun run check-types`
- `bun run test` — 80 tests passed
- `bun run --cwd apps/wish-start lint:strict`
- `bun run build` — passed with the existing >500 kB chunk warning
- focused EntityTable browser-DOM test covers indeterminate page selection, page-only toggling, and cross-page accumulation
- focused mutation tests cover successful bulk update, validation-before-write failure, and cascaded bulk deletion

## E2E evidence

- local app started successfully with the existing environment and returned HTTP 200
- a fresh Playwright/Chrome session reached the Wish sign-in landing page
- authenticated dashboard mutation E2E could not run because the isolated browser had no authenticated Clerk session

## Review loop

- Standards and issue-spec reviews completed in parallel
- fixed mutation-level coverage, pending-state selection controls, named export/style issues, indeterminate/current-page test coverage, and Status boundary validation
- ponytail + thermo-nuclear review found no remaining blocker or structural blocker

## Assumptions / deferred non-blockers

- Convex mutation transactions provide all-or-nothing writes
- the existing request deletion cascade remains the canonical deletion behavior
- migrate the small custom MutationCtx test fake to an official/shared harness only if backend mutation testing expands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection for requests and complaints in tables.
  * Added bulk status updates with pending-state feedback.
  * Added bulk deletion with confirmation and cascading cleanup.
  * Added controls to clear selections and display selected-item counts.
  * Added support for controlled row selection and current-page selection behavior.

* **Bug Fixes**
  * Improved validation to prevent invalid, missing, duplicate, or cross-project bulk operations.

* **Tests**
  * Added coverage for table selection, bulk updates, and bulk deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->