### PR TITLE
fix: update board state test

### DIFF
--- a/apps/wish-start/src/lib/requestBoard/__tests__/boardState.test.ts
+++ b/apps/wish-start/src/lib/requestBoard/__tests__/boardState.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   createMoveRequestToStatus,
   groupRequestsByStatus,
-  getRequestsForStatus,
   toUpvotedRequestSet,
 } from "../boardState";
 
@@ -20,14 +19,9 @@ describe("requestBoard boardState", () => {
 
     const grouped = groupRequestsByStatus(requests);
 
-    expect(getRequestsForStatus(grouped, statusA).map((request) => request._id)).toEqual([
-      "request-1",
-      "request-3",
-    ]);
-    expect(getRequestsForStatus(grouped, statusB).map((request) => request._id)).toEqual([
-      "request-2",
-    ]);
-    expect(getRequestsForStatus(grouped, "missing" as Id<"requestStatuses">)).toEqual([]);
+    expect(grouped[statusA].map((request) => request._id)).toEqual(["request-1", "request-3"]);
+    expect(grouped[statusB].map((request) => request._id)).toEqual(["request-2"]);
+    expect(grouped.missing).toBeUndefined();
   });
 
   it("creates a stable upvote set", () => {


### PR DESCRIPTION
## Summary
- remove the stale import of the deleted `getRequestsForStatus` helper
- assert directly against the grouped board state

## Validation
- `bun lint`
- `bun check-types`
- `bun run test`
- `bun run build`
- review-loop + thermo-nuclear review: approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated request board tests to validate grouped status results directly.
  * Added coverage confirming unavailable statuses return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->