### PR TITLE
feat: add handoff foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "convex-test": "0.0.54",
         "typescript": "^5.9.3",
       },
     },
@@ -911,6 +912,8 @@
     "convex": ["convex@1.33.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "3.8.1", "ws": "8.18.0" }, "optionalDependencies": { "@clerk/clerk-react": "5.61.3", "react": "19.2.4" }, "bin": { "convex": "bin/main.js" } }, "sha512-mRhR1XqZPLhgJsUepecM/kOgQVRCWKJtHHtyEX/XYY4zmzfItG0D1GNh5fjNEkuO5+72X4PCkzbEFA6327rxog=="],
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "optionalDependencies": { "@standard-schema/spec": "1.1.0", "hono": "4.12.8", "react": "19.2.4", "typescript": "5.9.3", "zod": "4.3.6" }, "peerDependencies": { "convex": "1.33.1" }, "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
+
+    "convex-test": ["convex-test@0.0.54", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-C0v2SQcuxrELAJRNzE6fQ686XDPor7UFoC22jcoJXeCRqhLo8ZIMZ4jyUHoo1UdAL2enCb0AbiprCVpLDN8u9Q=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 

--- a/packages/convex-backend/convex/_generated/api.d.ts
+++ b/packages/convex-backend/convex/_generated/api.d.ts
@@ -32,6 +32,9 @@ import type * as lib_requestStatusStarterData from "../lib/requestStatusStarterD
 import type * as lib_requestStatusWorkflow from "../lib/requestStatusWorkflow.js";
 import type * as lib_requesterIdentity from "../lib/requesterIdentity.js";
 import type * as lib_suggestionPortalReadModel from "../lib/suggestionPortalReadModel.js";
+import type * as lib_workItemHandoff from "../lib/workItemHandoff.js";
+import type * as lib_workTrackerSecrets from "../lib/workTrackerSecrets.js";
+import type * as lib_workTrackerTypes from "../lib/workTrackerTypes.js";
 import type * as mcpTokens from "../mcpTokens.js";
 import type * as notificationConnectors from "../notificationConnectors.js";
 import type * as notificationEvents from "../notificationEvents.js";
@@ -47,6 +50,7 @@ import type * as telegramBot from "../telegramBot.js";
 import type * as telegramNotifications from "../telegramNotifications.js";
 import type * as users from "../users.js";
 import type * as waitlist from "../waitlist.js";
+import type * as workItemHandoffs from "../workItemHandoffs.js";
 
 import type {
   ApiFromModules,
@@ -79,6 +83,9 @@ declare const fullApi: ApiFromModules<{
   "lib/requestStatusWorkflow": typeof lib_requestStatusWorkflow;
   "lib/requesterIdentity": typeof lib_requesterIdentity;
   "lib/suggestionPortalReadModel": typeof lib_suggestionPortalReadModel;
+  "lib/workItemHandoff": typeof lib_workItemHandoff;
+  "lib/workTrackerSecrets": typeof lib_workTrackerSecrets;
+  "lib/workTrackerTypes": typeof lib_workTrackerTypes;
   mcpTokens: typeof mcpTokens;
   notificationConnectors: typeof notificationConnectors;
   notificationEvents: typeof notificationEvents;
@@ -94,6 +101,7 @@ declare const fullApi: ApiFromModules<{
   telegramNotifications: typeof telegramNotifications;
   users: typeof users;
   waitlist: typeof waitlist;
+  workItemHandoffs: typeof workItemHandoffs;
 }>;
 
 /**

--- a/packages/convex-backend/convex/lib/workItemHandoff.test.ts
+++ b/packages/convex-backend/convex/lib/workItemHandoff.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  WORK_ITEM_HANDOFF_STATES,
+  canTransitionHandoff,
+  isHandoffBlocking,
+  isPendingLeaseExpired,
+} from "./workItemHandoff";
+
+describe("Work Item Handoff lifecycle", () => {
+  it("allows only the agreed lifecycle transitions", () => {
+    const allowed = new Set([
+      "pending:succeeded",
+      "pending:failed",
+      "pending:unknown",
+      "failed:pending",
+      "unknown:succeeded",
+    ]);
+
+    for (const from of WORK_ITEM_HANDOFF_STATES) {
+      for (const to of WORK_ITEM_HANDOFF_STATES) {
+        expect(canTransitionHandoff(from, to)).toBe(allowed.has(`${from}:${to}`));
+      }
+    }
+  });
+
+  it("blocks destructive connection changes only for unresolved Handoffs", () => {
+    expect(isHandoffBlocking("pending")).toBe(true);
+    expect(isHandoffBlocking("unknown")).toBe(true);
+    expect(isHandoffBlocking("failed")).toBe(false);
+    expect(isHandoffBlocking("succeeded")).toBe(false);
+  });
+
+  it("expires a pending lease when its deadline passes", () => {
+    expect(isPendingLeaseExpired(999, 1000)).toBe(true);
+    expect(isPendingLeaseExpired(1000, 1000)).toBe(true);
+    expect(isPendingLeaseExpired(1001, 1000)).toBe(false);
+  });
+});

--- a/packages/convex-backend/convex/lib/workItemHandoff.ts
+++ b/packages/convex-backend/convex/lib/workItemHandoff.ts
@@ -1,0 +1,24 @@
+export const WORK_ITEM_HANDOFF_STATES = ["pending", "succeeded", "failed", "unknown"] as const;
+export const WORK_ITEM_HANDOFF_LEASE_MS = 60_000;
+
+const transitions = {
+  pending: ["succeeded", "failed", "unknown"],
+  succeeded: [],
+  failed: ["pending"],
+  unknown: ["succeeded"],
+} as const;
+
+export function canTransitionHandoff(
+  from: (typeof WORK_ITEM_HANDOFF_STATES)[number],
+  to: (typeof WORK_ITEM_HANDOFF_STATES)[number],
+) {
+  return (transitions[from] as readonly string[]).includes(to);
+}
+
+export function isHandoffBlocking(state: (typeof WORK_ITEM_HANDOFF_STATES)[number]) {
+  return state === "pending" || state === "unknown";
+}
+
+export function isPendingLeaseExpired(leaseExpiresAt: number, now: number) {
+  return leaseExpiresAt <= now;
+}

--- a/packages/convex-backend/convex/lib/workTrackerSecrets.test.ts
+++ b/packages/convex-backend/convex/lib/workTrackerSecrets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { decryptWorkTrackerSecret, encryptWorkTrackerSecret } from "./workTrackerSecrets";
+
+const key = btoa(String.fromCharCode(...new Uint8Array(32).fill(7)));
+const wrongKey = btoa(String.fromCharCode(...new Uint8Array(32).fill(8)));
+
+describe("Work Tracker secret encryption", () => {
+  it("round-trips a secret with AES-GCM", async () => {
+    const encrypted = await encryptWorkTrackerSecret("linear-token", key);
+    const encryptedAgain = await encryptWorkTrackerSecret("linear-token", key);
+
+    expect(await decryptWorkTrackerSecret(encrypted, key)).toBe("linear-token");
+    expect(encrypted.ciphertext).not.toContain("linear-token");
+    expect(encrypted.iv).not.toBe(encryptedAgain.iv);
+  });
+
+  it("rejects invalid keys and tampered ciphertext", async () => {
+    await expect(encryptWorkTrackerSecret("linear-token", "bad-key")).rejects.toThrow(
+      "Work Tracker encryption key must be 32 bytes encoded as base64",
+    );
+
+    const encrypted = await encryptWorkTrackerSecret("linear-token", key);
+    await expect(decryptWorkTrackerSecret(encrypted, wrongKey)).rejects.toThrow(
+      "Unable to decrypt Work Tracker secret",
+    );
+
+    const tampered = {
+      ...encrypted,
+      ciphertext: `${encrypted.ciphertext.slice(0, -2)}AA`,
+    };
+
+    await expect(decryptWorkTrackerSecret(tampered, key)).rejects.toThrow(
+      "Unable to decrypt Work Tracker secret",
+    );
+  });
+});

--- a/packages/convex-backend/convex/lib/workTrackerSecrets.ts
+++ b/packages/convex-backend/convex/lib/workTrackerSecrets.ts
@@ -1,0 +1,60 @@
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+
+function decodeEncryptionKey(value: string) {
+  try {
+    const bytes = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+    if (bytes.length === KEY_LENGTH) {
+      return bytes;
+    }
+  } catch {
+    // The stable error below is safer than leaking decoder details.
+  }
+
+  throw new Error("Work Tracker encryption key must be 32 bytes encoded as base64");
+}
+
+function encodeBase64(value: Uint8Array) {
+  return btoa(String.fromCharCode(...value));
+}
+
+function decodeBase64(value: string) {
+  return Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+}
+
+async function importEncryptionKey(value: string, usage: KeyUsage) {
+  return await crypto.subtle.importKey("raw", decodeEncryptionKey(value), "AES-GCM", false, [usage]);
+}
+
+export async function encryptWorkTrackerSecret(plaintext: string, encryptionKey: string) {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const key = await importEncryptionKey(encryptionKey, "encrypt");
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+
+  return {
+    ciphertext: encodeBase64(new Uint8Array(ciphertext)),
+    iv: encodeBase64(iv),
+  };
+}
+
+export async function decryptWorkTrackerSecret(
+  encrypted: { ciphertext: string; iv: string },
+  encryptionKey: string,
+) {
+  const key = await importEncryptionKey(encryptionKey, "decrypt");
+
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: decodeBase64(encrypted.iv) },
+      key,
+      decodeBase64(encrypted.ciphertext),
+    );
+    return new TextDecoder().decode(plaintext);
+  } catch {
+    throw new Error("Unable to decrypt Work Tracker secret");
+  }
+}

--- a/packages/convex-backend/convex/lib/workTrackerTypes.ts
+++ b/packages/convex-backend/convex/lib/workTrackerTypes.ts
@@ -1,0 +1,69 @@
+import { v } from "convex/values";
+
+export const workTrackerProviderValidator = v.literal("linear");
+
+export const workTrackerConnectionHealthValidator = v.union(
+  v.literal("active"),
+  v.literal("needs_attention"),
+);
+
+const encryptedCredentialsValidator = v.object({
+  ciphertext: v.string(),
+  iv: v.string(),
+});
+
+export const workTrackerConnectionDataValidator = v.object({
+  provider: v.literal("linear"),
+  organizationId: v.string(),
+  organizationName: v.string(),
+  teamId: v.string(),
+  teamName: v.string(),
+  encryptedCredentials: encryptedCredentialsValidator,
+});
+
+export const workTrackerOAuthSetupDataValidator = v.object({
+  provider: v.literal("linear"),
+  authorization: v.optional(
+    v.object({
+      encryptedCredentials: encryptedCredentialsValidator,
+    }),
+  ),
+});
+
+export const workItemHandoffRecoveryValidator = v.object({
+  provider: v.literal("linear"),
+  issueId: v.string(),
+});
+
+export const externalWorkItemIdentityValidator = v.object({
+  provider: v.literal("linear"),
+  id: v.string(),
+  identifier: v.string(),
+  url: v.string(),
+});
+
+const handoffErrorFields = {
+  errorCode: v.optional(v.string()),
+  errorMessage: v.optional(v.string()),
+  providerCorrelationId: v.optional(v.string()),
+};
+
+export const workItemHandoffLifecycleValidator = v.union(
+  v.object({
+    state: v.literal("pending"),
+    leaseExpiresAt: v.number(),
+  }),
+  v.object({
+    state: v.literal("succeeded"),
+    externalIdentity: externalWorkItemIdentityValidator,
+    succeededAt: v.number(),
+  }),
+  v.object({
+    state: v.literal("failed"),
+    ...handoffErrorFields,
+  }),
+  v.object({
+    state: v.literal("unknown"),
+    ...handoffErrorFields,
+  }),
+);

--- a/packages/convex-backend/convex/schema.ts
+++ b/packages/convex-backend/convex/schema.ts
@@ -5,6 +5,14 @@ import {
   notificationConnectorKindValidator,
   notificationEventTypeValidator,
 } from "./lib/notificationTypes";
+import {
+  workItemHandoffLifecycleValidator,
+  workItemHandoffRecoveryValidator,
+  workTrackerConnectionDataValidator,
+  workTrackerConnectionHealthValidator,
+  workTrackerOAuthSetupDataValidator,
+  workTrackerProviderValidator,
+} from "./lib/workTrackerTypes";
 
 export default defineSchema({
   users: defineTable({
@@ -110,6 +118,47 @@ export default defineSchema({
     .index("by_event", ["eventId"])
     .index("by_status", ["status"])
     .index("by_project", ["projectId"]),
+
+  workTrackerConnections: defineTable({
+    projectId: v.id("projects"),
+    provider: workTrackerProviderValidator,
+    health: workTrackerConnectionHealthValidator,
+    destinationLabel: v.string(),
+    data: workTrackerConnectionDataValidator,
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_project_provider", ["projectId", "provider"]),
+
+  workTrackerOAuthSetups: defineTable({
+    projectId: v.id("projects"),
+    provider: workTrackerProviderValidator,
+    stateHash: v.string(),
+    data: workTrackerOAuthSetupDataValidator,
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    expiresAt: v.number(),
+    consumedAt: v.optional(v.number()),
+  })
+    .index("by_state_hash", ["stateHash"])
+    .index("by_project_provider", ["projectId", "provider"])
+    .index("by_expires_at", ["expiresAt"]),
+
+  workItemHandoffs: defineTable({
+    projectId: v.id("projects"),
+    requestId: v.id("requests"),
+    provider: workTrackerProviderValidator,
+    attemptCount: v.number(),
+    reconciliationCount: v.number(),
+    recovery: workItemHandoffRecoveryValidator,
+    lifecycle: workItemHandoffLifecycleValidator,
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_request_provider", ["requestId", "provider"])
+    .index("by_project_provider_state", ["projectId", "provider", "lifecycle.state"]),
 
   requests: defineTable({
     text: v.string(),

--- a/packages/convex-backend/convex/workItemHandoffs.test.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.test.ts
@@ -1,0 +1,48 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vite-plus/test";
+
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = {
+  "./_generated/server.ts": () => import("./_generated/server"),
+  "./workItemHandoffs.ts": () => import("./workItemHandoffs"),
+};
+
+describe("Work Item Handoff reservation", () => {
+  it("atomically reuses the Handoff reserved for a source and provider", async () => {
+    const t = convexTest(schema, modules);
+    const { projectId, requestId } = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        name: "Owner",
+        tokenIdentifier: "owner-token",
+      });
+      const projectId = await ctx.db.insert("projects", { title: "Project", user: userId });
+      const statusId = await ctx.db.insert("requestStatuses", {
+        name: "open",
+        displayName: "Open",
+        project: projectId,
+        type: "custom",
+      });
+      const requestId = await ctx.db.insert("requests", {
+        text: "Export reports",
+        clientId: "client",
+        status: statusId,
+        project: projectId,
+      });
+      return { projectId, requestId };
+    });
+
+    const args = { projectId, requestId, provider: "linear" as const };
+    const [first, second] = await Promise.all([
+      t.mutation(internal.workItemHandoffs.reserveInternal, args),
+      t.mutation(internal.workItemHandoffs.reserveInternal, args),
+    ]);
+
+    expect(second._id).toBe(first._id);
+    expect(second.recovery.issueId).toBe(first.recovery.issueId);
+    expect(await t.run(async (ctx) => await ctx.db.query("workItemHandoffs").collect())).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/convex-backend/convex/workItemHandoffs.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.ts
@@ -1,0 +1,54 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "./_generated/server";
+import { WORK_ITEM_HANDOFF_LEASE_MS } from "./lib/workItemHandoff";
+import { workTrackerProviderValidator } from "./lib/workTrackerTypes";
+
+export const reserveInternal = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    requestId: v.id("requests"),
+    provider: workTrackerProviderValidator,
+  },
+  handler: async (ctx, args) => {
+    const request = await ctx.db.get(args.requestId);
+    if (!request || request.project !== args.projectId) {
+      throw new Error("Request does not belong to the Project Board");
+    }
+
+    const existing = await ctx.db
+      .query("workItemHandoffs")
+      .withIndex("by_request_provider", (q) =>
+        q.eq("requestId", args.requestId).eq("provider", args.provider),
+      )
+      .unique();
+    if (existing) {
+      return existing;
+    }
+
+    const now = Date.now();
+    const handoffId = await ctx.db.insert("workItemHandoffs", {
+      projectId: args.projectId,
+      requestId: args.requestId,
+      provider: args.provider,
+      attemptCount: 1,
+      reconciliationCount: 0,
+      recovery: {
+        provider: "linear",
+        issueId: crypto.randomUUID(),
+      },
+      lifecycle: {
+        state: "pending",
+        leaseExpiresAt: now + WORK_ITEM_HANDOFF_LEASE_MS,
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+    const handoff = await ctx.db.get(handoffId);
+    if (!handoff) {
+      throw new Error("Work Item Handoff reservation failed");
+    }
+
+    return handoff;
+  },
+});

--- a/packages/convex-backend/package.json
+++ b/packages/convex-backend/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "convex-test": "0.0.54",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- add shared Work Tracker connection, OAuth setup, and Handoff tables
- model explicit pending/succeeded/failed/unknown Handoff lifecycles
- add AES-256-GCM credential encryption helpers
- reserve one durable Linear Handoff per request/provider in a single Convex transaction

First layer of the stack specified in #52 and #60.

## Validation
- `bun lint`
- `bun check-types`
- `bun run test` — 78 tests passed
- `bun run build`
- `git diff --check origin/main...HEAD`
- review-loop + thermo-nuclear review — approved after four rounds

## Review note
`convex-test` serializes top-level mutations, so the reservation test is not a literal race simulation. Production uniqueness is enforced by Convex serializable transaction semantics around the indexed `.unique()` read and insert.