### PR TITLE
feat: add Linear connection

### DIFF
--- a/apps/wish-start/src/components/Organisms/AppSidebar.tsx
+++ b/apps/wish-start/src/components/Organisms/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useParams } from "@tanstack/react-router";
+import { Link, useLocation, useParams, useRouter } from "@tanstack/react-router";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -14,6 +14,7 @@ import {
 import type { ReactNode } from "react";
 
 import ProjectSettings from "@/components/project/ProjectSettings";
+import { parseLinearCallbackResult } from "@/lib/linearWorkTrackerUi";
 import {
   Sidebar,
   SidebarContent,
@@ -75,11 +76,29 @@ interface Props {
 
 export function AppSidebar({ footer }: Props) {
   const { projectId, slug } = useParams({ strict: false });
+  const location = useLocation();
+  const router = useRouter();
+  const search = new URLSearchParams(location.searchStr);
 
   return (
     <Sidebar variant="floating" className="z-20">
       <SidebarContent>
-        {projectId && slug ? <ProjectNav projectId={projectId} slug={slug} /> : <GlobalNav />}
+        {projectId && slug ? (
+          <ProjectNav
+            projectId={projectId}
+            slug={slug}
+            requestedSettings={search.get("settings") === "work-trackers" ? "work-trackers" : undefined}
+            linearResult={parseLinearCallbackResult(search.get("linear"))}
+            onSettingsClose={() => {
+              search.delete("settings");
+              search.delete("linear");
+              const suffix = search.toString();
+              router.history.replace(`${location.pathname}${suffix ? `?${suffix}` : ""}`);
+            }}
+          />
+        ) : (
+          <GlobalNav />
+        )}
       </SidebarContent>
       <SidebarFooter>{footer}</SidebarFooter>
     </Sidebar>
@@ -108,7 +127,19 @@ function GlobalNav() {
   );
 }
 
-function ProjectNav({ projectId, slug }: { projectId: string; slug: string }) {
+function ProjectNav({
+  linearResult,
+  onSettingsClose,
+  projectId,
+  requestedSettings,
+  slug,
+}: {
+  linearResult?: string;
+  onSettingsClose: () => void;
+  projectId: string;
+  requestedSettings?: string;
+  slug: string;
+}) {
   const { pathname } = useLocation();
   const base = `/dashboard/project/${projectId}/${slug}`;
 
@@ -146,7 +177,12 @@ function ProjectNav({ projectId, slug }: { projectId: string; slug: string }) {
               </SidebarMenuItem>
             ))}
             <SidebarMenuItem>
-              <ProjectSettings projectID={projectId as never}>
+              <ProjectSettings
+                projectID={projectId as never}
+                requestedSection={requestedSettings}
+                linearResult={linearResult}
+                onUrlClose={onSettingsClose}
+              >
                 <SidebarMenuButton>
                   <Cog />
                   <span>Settings</span>

--- a/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
+++ b/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+import { useAsyncAction } from "#/hooks/useAsyncAction";
+import { api } from "@wish/convex-backend/api";
+import type { Id } from "@wish/convex-backend/data-model";
+import { useAction, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import {
+  AlertTriangle,
+  Check,
+  ChartNoAxesGantt,
+  Link2,
+  RefreshCw,
+  Unplug,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { toast } from "sonner";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { getInitialLinearTeamId, parseLinearCallbackResult } from "@/lib/linearWorkTrackerUi";
+
+const callbackMessages = {
+  authorized: {
+    title: "Linear authorized",
+    description: "Choose the team that should receive new External Work Items.",
+  },
+  invalid_callback: {
+    title: "Linear did not complete authorization",
+    description: "Start the connection again from this page.",
+  },
+  invalid_state: {
+    title: "This Linear connection link expired",
+    description: "OAuth links are single-use and expire after ten minutes. Start again.",
+  },
+  authorization_denied: {
+    title: "Linear authorization was canceled",
+    description: "No active connection was changed.",
+  },
+  linear_exchange_failed: {
+    title: "Linear rejected the authorization exchange",
+    description: "No active connection was changed. Start again or check the Linear app settings.",
+  },
+  linear_discovery_failed: {
+    title: "Wish could not load Linear teams",
+    description: "No active connection was changed. Reauthorize and try again.",
+  },
+  linear_persistence_failed: {
+    title: "Wish could not save the Linear authorization",
+    description: "The new authorization was revoked. Start again.",
+  },
+};
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+export default function LinearWorkTrackerCard({
+  linearResult,
+  projectId,
+}: {
+  linearResult?: string;
+  projectId: Id<"projects">;
+}) {
+  const settings = useQuery(api.linearWorkTrackerSettings.getLinearSettings, { projectId });
+  const beginLinearOAuth = useAction(api.linearWorkTrackerOAuth.beginLinearOAuth);
+  const selectLinearTeam = useAction(api.workTrackerConnections.selectLinearTeam);
+  const discardLinearOAuthSetup = useAction(
+    api.linearWorkTrackerOAuth.discardLinearOAuthSetup,
+  );
+  const listLinearTeams = useAction(api.workTrackerConnections.listLinearTeams);
+  const changeLinearTeam = useAction(api.workTrackerConnections.changeLinearTeam);
+  const disconnectLinear = useAction(api.workTrackerConnections.disconnectLinear);
+  const connectAction = useAsyncAction();
+  const disconnectAction = useAsyncAction();
+  const [availableTeams, setAvailableTeams] = useState<Awaited<
+    ReturnType<typeof listLinearTeams>
+  > | null>(null);
+  const [selectedTeamId, setSelectedTeamId] = useState("");
+  const teamAction = useAsyncAction();
+  const connectionBusy =
+    connectAction.isLoading || disconnectAction.isLoading || teamAction.isLoading;
+
+  async function startAuthorization(promptForWorkspace = false, setupId?: Id<"workTrackerOAuthSetups">) {
+    await connectAction.execute(async () => {
+      try {
+        if (setupId) {
+          await discardLinearOAuthSetup({ projectId, setupId });
+        }
+        const result = await beginLinearOAuth({ projectId, promptForWorkspace });
+        window.location.assign(result.authorizationUrl);
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not start Linear authorization"));
+      }
+    });
+  }
+
+  async function cancelAuthorization(setupId: Id<"workTrackerOAuthSetups">) {
+    await connectAction.execute(async () => {
+      try {
+        await discardLinearOAuthSetup({ projectId, setupId });
+        toast.success("Linear authorization discarded");
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not discard the Linear authorization"));
+      }
+    });
+  }
+
+  async function loadTeams() {
+    await teamAction.execute(async () => {
+      try {
+        const teams = await listLinearTeams({ projectId });
+        setAvailableTeams(teams);
+        setSelectedTeamId(getInitialLinearTeamId(teams, settings?.connection?.team.id));
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not load Linear teams"));
+      }
+    });
+  }
+
+  async function saveTeam() {
+    if (!selectedTeamId) return;
+    await teamAction.execute(async () => {
+      try {
+        const result = await changeLinearTeam({ projectId, teamId: selectedTeamId });
+        setAvailableTeams(null);
+        toast.success(`Linear destination changed to ${result.team.name}`);
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not change the Linear team"));
+      }
+    });
+  }
+
+  async function disconnect() {
+    await disconnectAction.execute(async () => {
+      try {
+        await disconnectLinear({ projectId });
+        setAvailableTeams(null);
+        toast.success("Linear disconnected");
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not disconnect Linear"));
+      }
+    });
+  }
+
+  const parsedLinearResult = parseLinearCallbackResult(linearResult);
+  const callbackMessage = parsedLinearResult ? callbackMessages[parsedLinearResult] : null;
+  const showCallbackMessage =
+    callbackMessage && (parsedLinearResult !== "authorized" || Boolean(settings?.setup));
+
+  return (
+    <div className="space-y-5">
+      {showCallbackMessage ? (
+        <Alert variant={parsedLinearResult === "authorized" ? "default" : "destructive"}>
+          {parsedLinearResult === "authorized" ? <Check /> : <AlertTriangle />}
+          <AlertTitle>{callbackMessage.title}</AlertTitle>
+          <AlertDescription>{callbackMessage.description}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {settings && !settings.configured ? (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertTitle>Linear is not configured</AlertTitle>
+          <AlertDescription>
+            A deployment administrator must configure Linear OAuth before Project Owners can use
+            this connection.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {settings?.cleanupSetupId ? (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertTitle>A failed Linear authorization still needs cleanup</AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p>No active connection was changed. Revoke the failed authorization before retrying.</p>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={connectionBusy}
+              onClick={() => void cancelAuthorization(settings.cleanupSetupId!)}
+            >
+              Discard authorization
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card className="overflow-hidden border-orange-500/15 bg-card/75 shadow-sm">
+        <CardHeader className="border-b bg-muted/20">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 items-center justify-center rounded-lg bg-foreground text-background">
+                <ChartNoAxesGantt className="size-5" />
+              </div>
+              <div>
+                <CardTitle className="text-base">Linear</CardTitle>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  One workspace and one destination team for this Project Board.
+                </p>
+              </div>
+            </div>
+            <Badge
+              variant={
+                settings?.connection?.health === "active"
+                  ? "default"
+                  : settings?.connection
+                    ? "destructive"
+                    : "secondary"
+              }
+            >
+              {settings?.connection?.health === "active"
+                ? "Connected"
+                : settings?.connection
+                  ? "Needs attention"
+                  : "Not connected"}
+            </Badge>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-5 pt-5">
+          {settings === undefined ? (
+            <div className="flex min-h-32 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : settings.setup ? (
+            <AuthorizedLinearSetup
+              key={settings.setup.id}
+              setup={settings.setup}
+              isSaving={connectionBusy}
+              onCancel={() => void cancelAuthorization(settings.setup!.id)}
+              onStartAgain={() => void startAuthorization(true, settings.setup!.id)}
+              onSave={async (teamId) => {
+                await connectAction.execute(async () => {
+                  try {
+                    const result = await selectLinearTeam({
+                      projectId,
+                      setupId: settings.setup!.id,
+                      teamId,
+                    });
+                    toast.success(`Linear connected to ${result.team.name}`);
+                  } catch (error) {
+                    toast.error(errorMessage(error, "Could not save the Linear destination"));
+                  }
+                });
+              }}
+            />
+          ) : settings.connection ? (
+            <div className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <ConnectionFact label="Workspace" value={settings.connection.organization.name} />
+                <ConnectionFact
+                  label="Destination team"
+                  value={`${settings.connection.team.name} · ${settings.connection.team.key}`}
+                />
+              </div>
+
+              {availableTeams ? (
+                <div className="rounded-xl border bg-muted/20 p-4">
+                  <div className="mb-3">
+                    <p className="font-medium">Change destination team</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      This affects future sends only. Existing Linear links do not move.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Select value={selectedTeamId} onValueChange={setSelectedTeamId}>
+                      <SelectTrigger className="min-w-64" aria-label="Linear destination team">
+                        <SelectValue placeholder="Choose a team" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableTeams.map((team) => (
+                          <SelectItem key={team.id} value={team.id}>
+                            {team.name} · {team.key}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      disabled={!selectedTeamId || connectionBusy}
+                      onClick={() => void saveTeam()}
+                    >
+                      Save team
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      disabled={connectionBusy}
+                      onClick={() => setAvailableTeams(null)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2 border-t pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={connectionBusy}
+                  onClick={() => void loadTeams()}
+                >
+                  <RefreshCw /> Change team
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={connectionBusy}
+                  onClick={() => void startAuthorization(true)}
+                >
+                  <Link2 /> Connect another workspace
+                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button type="button" variant="ghost" disabled={connectionBusy}>
+                      <Unplug /> Disconnect
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Disconnect Linear?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Wish will revoke its Linear access. Historical External Work Item links stay
+                        available, and Linear issues are never deleted.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => void disconnect()}>
+                        Disconnect Linear
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </div>
+          ) : settings.configured ? (
+            <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
+              <SetupStep number="1" title="Authorize Linear" active>
+                A Linear workspace admin grants Wish read and issue-creation access.
+                <div className="mt-4">
+                  <Button
+                    type="button"
+                    disabled={connectionBusy}
+                    onClick={() => void startAuthorization()}
+                  >
+                    <Link2 /> Authorize Linear
+                  </Button>
+                </div>
+              </SetupStep>
+              <div className="hidden items-center text-muted-foreground sm:flex">→</div>
+              <SetupStep number="2" title="Choose a team">
+                After authorization, choose exactly one destination team for future sends.
+              </SetupStep>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Linear authorization is unavailable until the deployment is configured.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function AuthorizedLinearSetup({
+  isSaving,
+  onCancel,
+  onStartAgain,
+  onSave,
+  setup,
+}: {
+  isSaving: boolean;
+  onCancel: () => void;
+  onStartAgain: () => void;
+  onSave: (teamId: string) => Promise<void>;
+  setup: NonNullable<
+    FunctionReturnType<typeof api.linearWorkTrackerSettings.getLinearSettings>["setup"]
+  >;
+}) {
+  const [teamId, setTeamId] = useState(setup.teams.length === 1 ? setup.teams[0].id : "");
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
+        <SetupStep number="1" title="Linear authorized" complete>
+          {setup.organization.name} granted access. Credentials stay encrypted in Wish.
+        </SetupStep>
+        <div className="hidden items-center text-muted-foreground sm:flex">→</div>
+        <SetupStep number="2" title="Choose a team" active>
+          {setup.teams.length > 0
+            ? "Select the Linear team that should receive future External Work Items."
+            : "This installation does not expose any teams to Wish."}
+        </SetupStep>
+      </div>
+
+      {setup.replacesWorkspace ? (
+        <Alert>
+          <AlertTriangle />
+          <AlertTitle>This replaces the connected workspace</AlertTitle>
+          <AlertDescription>
+            Historical issue links remain unchanged. Only future sends use the new workspace.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-muted/20 p-4">
+        {setup.teams.length > 0 ? (
+          <Select value={teamId} onValueChange={setTeamId}>
+            <SelectTrigger className="min-w-64" aria-label="Linear destination team">
+              <SelectValue placeholder="Choose a Linear team" />
+            </SelectTrigger>
+            <SelectContent>
+              {setup.teams.map((team) => (
+                <SelectItem key={team.id} value={team.id}>
+                  {team.name} · {team.key}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+        <Button type="button" disabled={!teamId || isSaving} onClick={() => void onSave(teamId)}>
+          <Check /> Save destination
+        </Button>
+        <Button type="button" variant="ghost" disabled={isSaving} onClick={onCancel}>
+          Cancel setup
+        </Button>
+        <Button type="button" variant="ghost" disabled={isSaving} onClick={onStartAgain}>
+          Start again
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SetupStep({
+  active,
+  children,
+  complete,
+  number,
+  title,
+}: {
+  active?: boolean;
+  children: ReactNode;
+  complete?: boolean;
+  number: string;
+  title: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl border p-4 ${active ? "border-orange-500/30 bg-orange-500/5" : "bg-muted/15"}`}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${complete ? "bg-foreground text-background" : active ? "bg-orange-600 text-white" : "bg-muted text-muted-foreground"}`}
+        >
+          {complete ? <Check className="size-3.5" /> : number}
+        </span>
+        <p className="font-medium">{title}</p>
+      </div>
+      <div className="mt-2 text-sm leading-6 text-muted-foreground">{children}</div>
+    </div>
+  );
+}
+
+function ConnectionFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border bg-muted/15 p-4">
+      <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">{label}</p>
+      <p className="mt-1 font-medium">{value}</p>
+    </div>
+  );
+}

--- a/apps/wish-start/src/components/project/ProjectSettings.tsx
+++ b/apps/wish-start/src/components/project/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { Id } from "@wish/convex-backend/data-model";
 import type { ReactElement, ReactNode } from "react";
+import { useState } from "react";
 
 import { SettingsView, SettingsContent } from "../settings/SettingsView";
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from "../ui/dialog";
@@ -9,13 +10,24 @@ import ProjectApiKeysManager from "./ProjectApiKeysManager";
 import ProjectGeneralSettings from "./ProjectGeneralSettings";
 import ProjectNotificationConnectorsManager from "./ProjectNotificationConnectorsManager";
 import ProjectStatusesManager from "./ProjectStatusesManager";
+import ProjectWorkTrackersManager from "./ProjectWorkTrackersManager";
 
 interface ProjectSettingsProps {
   projectID: Id<"projects">;
   children: ReactElement;
+  linearResult?: string;
+  onUrlClose?: () => void;
+  requestedSection?: string;
 }
 
-export default function ProjectSettings({ children, projectID }: ProjectSettingsProps) {
+export default function ProjectSettings({
+  children,
+  linearResult,
+  onUrlClose,
+  projectID,
+  requestedSection,
+}: ProjectSettingsProps) {
+  const [open, setOpen] = useState(false);
   const sections: Array<{ key: string; label: string; content: ReactNode }> = [
     {
       key: "general",
@@ -37,19 +49,41 @@ export default function ProjectSettings({ children, projectID }: ProjectSettings
       label: "Connectors",
       content: <ProjectNotificationConnectorsManager projectId={projectID} />,
     },
+    {
+      key: "work-trackers",
+      label: "Work Trackers",
+      content: <ProjectWorkTrackersManager projectId={projectID} linearResult={linearResult} />,
+    },
   ];
 
+  const activeRequestedSection = sections.some((section) => section.key === requestedSection)
+    ? requestedSection
+    : undefined;
+  const urlOpen = activeRequestedSection === "work-trackers";
+
   return (
-    <Dialog>
+    <Dialog
+      open={open || urlOpen}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen && urlOpen) {
+          onUrlClose?.();
+        }
+      }}
+    >
       <DialogTrigger asChild>{children}</DialogTrigger>
 
       <DialogContent className="max-h-[88vh] w-[96vw] overflow-y-auto sm:w-[92vw] sm:max-w-none lg:w-295 xl:w-330">
         <DialogTitle className="sr-only">Project settings</DialogTitle>
         <DialogDescription className="sr-only">
-          Manage the project name, statuses, API keys, and notification connectors.
+          Manage the project name, statuses, API keys, connectors, and Work Trackers.
         </DialogDescription>
 
-        <SettingsView navigation={sections.map(({ key, label }) => ({ key, label }))}>
+        <SettingsView
+          key={activeRequestedSection ?? "default"}
+          defaultValue={activeRequestedSection}
+          navigation={sections.map(({ key, label }) => ({ key, label }))}
+        >
           {sections.map((section) => (
             <SettingsContent key={section.key} value={section.key}>
               {section.content}

--- a/apps/wish-start/src/components/project/ProjectWorkTrackersManager.tsx
+++ b/apps/wish-start/src/components/project/ProjectWorkTrackersManager.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { Id } from "@wish/convex-backend/data-model";
+import { CircleDot } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+
+import LinearWorkTrackerCard from "./LinearWorkTrackerCard";
+
+export default function ProjectWorkTrackersManager({
+  linearResult,
+  projectId,
+}: {
+  linearResult?: string;
+  projectId: Id<"projects">;
+}) {
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3>Work Trackers</h3>
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Send Requests and Complaints to the tools where your team plans and delivers work.
+            Creation is always an explicit Project Owner action.
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className="mr-8 border-orange-500/30 text-orange-700 dark:text-orange-300"
+        >
+          <CircleDot /> Linear first
+        </Badge>
+      </div>
+
+      <LinearWorkTrackerCard projectId={projectId} linearResult={linearResult} />
+    </div>
+  );
+}

--- a/apps/wish-start/src/components/settings/SettingsView.tsx
+++ b/apps/wish-start/src/components/settings/SettingsView.tsx
@@ -11,11 +11,16 @@ interface SettingsSection {
 
 interface SettingsViewProps extends PropsWithChildren {
   navigation: SettingsSection[];
+  defaultValue?: string;
 }
 
-const SettingsView: FC<SettingsViewProps> = ({ children, navigation }) => {
+const SettingsView: FC<SettingsViewProps> = ({ children, defaultValue, navigation }) => {
   return (
-    <Tabs orientation="vertical" defaultValue={navigation[0]?.key} className="gap-0">
+    <Tabs
+      orientation="vertical"
+      defaultValue={defaultValue ?? navigation[0]?.key}
+      className="gap-0"
+    >
       <div className="grid grid-cols-1 gap-4 md:grid-cols-12">
         <div className="border-b border-neutral-800 pb-4 md:col-span-3 md:border-r md:border-b-0 md:pr-4 md:pb-0">
           <TabsList className="h-auto w-full flex-col items-stretch justify-start gap-1 rounded-none bg-transparent p-0">

--- a/apps/wish-start/src/lib/linearWorkTrackerUi.test.ts
+++ b/apps/wish-start/src/lib/linearWorkTrackerUi.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getInitialLinearTeamId, parseLinearCallbackResult } from "./linearWorkTrackerUi";
+
+describe("Linear Work Tracker UI", () => {
+  it("selects only an accessible current team or a sole alternative", () => {
+    expect(getInitialLinearTeamId([], "missing")).toBe("");
+    expect(getInitialLinearTeamId([{ id: "new" }], "missing")).toBe("new");
+    expect(getInitialLinearTeamId([{ id: "one" }, { id: "two" }], "missing")).toBe("");
+    expect(getInitialLinearTeamId([{ id: "one" }, { id: "two" }], "two")).toBe("two");
+  });
+
+  it("accepts only known callback results", () => {
+    expect(parseLinearCallbackResult("authorized")).toBe("authorized");
+    expect(parseLinearCallbackResult("toString")).toBeUndefined();
+    expect(parseLinearCallbackResult("__proto__")).toBeUndefined();
+  });
+});

--- a/apps/wish-start/src/lib/linearWorkTrackerUi.ts
+++ b/apps/wish-start/src/lib/linearWorkTrackerUi.ts
@@ -1,0 +1,18 @@
+export function getInitialLinearTeamId(teams: { id: string }[], currentTeamId?: string) {
+  if (currentTeamId && teams.some((team) => team.id === currentTeamId)) return currentTeamId;
+  return teams.length === 1 ? teams[0].id : "";
+}
+
+const callbackResults = [
+  "authorized",
+  "authorization_denied",
+  "invalid_callback",
+  "invalid_state",
+  "linear_exchange_failed",
+  "linear_discovery_failed",
+  "linear_persistence_failed",
+] as const;
+
+export function parseLinearCallbackResult(value?: string | null) {
+  return callbackResults.find((result) => result === value);
+}

--- a/docs/work-tracker-deployment.md
+++ b/docs/work-tracker-deployment.md
@@ -1,0 +1,25 @@
+# Work Tracker deployment
+
+Linear OAuth stays disabled in Project Settings until all five Convex deployment variables exist:
+
+- `LINEAR_CLIENT_ID`
+- `LINEAR_CLIENT_SECRET`
+- `LINEAR_REDIRECT_URI`
+- `WORK_TRACKER_ENCRYPTION_KEY`
+- `WISH_APP_BASE_URL`
+
+Set `LINEAR_REDIRECT_URI` to the fixed HTTPS callback registered in Linear:
+
+```text
+https://<convex-http-host>/work-trackers/linear/callback
+```
+
+Set `WISH_APP_BASE_URL` to the fixed HTTPS origin that owns the dashboard redirects. Localhost HTTP
+is accepted for development only. Generate the encryption key as 32 random bytes encoded as base64:
+
+```bash
+openssl rand -base64 32
+```
+
+After setting the variables, deploy Convex and verify the Work Trackers settings card reports Linear
+as available before enabling the flow for Project Owners.

--- a/packages/convex-backend/convex/_generated/api.d.ts
+++ b/packages/convex-backend/convex/_generated/api.d.ts
@@ -10,10 +10,13 @@
 
 import type * as apiKeys from "../apiKeys.js";
 import type * as changelogEntries from "../changelogEntries.js";
+import type * as crons from "../crons.js";
 import type * as http from "../http.js";
 import type * as lib_apiKeys from "../lib/apiKeys.js";
 import type * as lib_authorization from "../lib/authorization.js";
 import type * as lib_changelogIntake from "../lib/changelogIntake.js";
+import type * as lib_linearConnection from "../lib/linearConnection.js";
+import type * as lib_linearOAuth from "../lib/linearOAuth.js";
 import type * as lib_mcpServer from "../lib/mcpServer.js";
 import type * as lib_mcpToken from "../lib/mcpToken.js";
 import type * as lib_notificationEventTypes from "../lib/notificationEventTypes.js";
@@ -33,8 +36,12 @@ import type * as lib_requestStatusWorkflow from "../lib/requestStatusWorkflow.js
 import type * as lib_requesterIdentity from "../lib/requesterIdentity.js";
 import type * as lib_suggestionPortalReadModel from "../lib/suggestionPortalReadModel.js";
 import type * as lib_workItemHandoff from "../lib/workItemHandoff.js";
+import type * as lib_workTrackerGuards from "../lib/workTrackerGuards.js";
 import type * as lib_workTrackerSecrets from "../lib/workTrackerSecrets.js";
 import type * as lib_workTrackerTypes from "../lib/workTrackerTypes.js";
+import type * as linearWorkTrackerCleanup from "../linearWorkTrackerCleanup.js";
+import type * as linearWorkTrackerOAuth from "../linearWorkTrackerOAuth.js";
+import type * as linearWorkTrackerSettings from "../linearWorkTrackerSettings.js";
 import type * as mcpTokens from "../mcpTokens.js";
 import type * as notificationConnectors from "../notificationConnectors.js";
 import type * as notificationEvents from "../notificationEvents.js";
@@ -51,6 +58,7 @@ import type * as telegramNotifications from "../telegramNotifications.js";
 import type * as users from "../users.js";
 import type * as waitlist from "../waitlist.js";
 import type * as workItemHandoffs from "../workItemHandoffs.js";
+import type * as workTrackerConnections from "../workTrackerConnections.js";
 
 import type {
   ApiFromModules,
@@ -61,10 +69,13 @@ import type {
 declare const fullApi: ApiFromModules<{
   apiKeys: typeof apiKeys;
   changelogEntries: typeof changelogEntries;
+  crons: typeof crons;
   http: typeof http;
   "lib/apiKeys": typeof lib_apiKeys;
   "lib/authorization": typeof lib_authorization;
   "lib/changelogIntake": typeof lib_changelogIntake;
+  "lib/linearConnection": typeof lib_linearConnection;
+  "lib/linearOAuth": typeof lib_linearOAuth;
   "lib/mcpServer": typeof lib_mcpServer;
   "lib/mcpToken": typeof lib_mcpToken;
   "lib/notificationEventTypes": typeof lib_notificationEventTypes;
@@ -84,8 +95,12 @@ declare const fullApi: ApiFromModules<{
   "lib/requesterIdentity": typeof lib_requesterIdentity;
   "lib/suggestionPortalReadModel": typeof lib_suggestionPortalReadModel;
   "lib/workItemHandoff": typeof lib_workItemHandoff;
+  "lib/workTrackerGuards": typeof lib_workTrackerGuards;
   "lib/workTrackerSecrets": typeof lib_workTrackerSecrets;
   "lib/workTrackerTypes": typeof lib_workTrackerTypes;
+  linearWorkTrackerCleanup: typeof linearWorkTrackerCleanup;
+  linearWorkTrackerOAuth: typeof linearWorkTrackerOAuth;
+  linearWorkTrackerSettings: typeof linearWorkTrackerSettings;
   mcpTokens: typeof mcpTokens;
   notificationConnectors: typeof notificationConnectors;
   notificationEvents: typeof notificationEvents;
@@ -102,6 +117,7 @@ declare const fullApi: ApiFromModules<{
   users: typeof users;
   waitlist: typeof waitlist;
   workItemHandoffs: typeof workItemHandoffs;
+  workTrackerConnections: typeof workTrackerConnections;
 }>;
 
 /**

--- a/packages/convex-backend/convex/crons.ts
+++ b/packages/convex-backend/convex/crons.ts
@@ -1,0 +1,21 @@
+import { cronJobs } from "convex/server";
+
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.interval(
+  "revoke abandoned Linear setups",
+  { minutes: 5 },
+  internal.linearWorkTrackerCleanup.cleanupExpiredLinearSetupsInternal,
+  {},
+);
+
+crons.interval(
+  "retry replaced Linear credential revocations",
+  { minutes: 5 },
+  internal.linearWorkTrackerCleanup.cleanupPendingLinearRevocationsInternal,
+  {},
+);
+
+export default crons;

--- a/packages/convex-backend/convex/http.ts
+++ b/packages/convex-backend/convex/http.ts
@@ -1,15 +1,16 @@
 import { type } from "arktype";
 import type { HonoWithConvex } from "convex-helpers/server/hono";
 import { HttpRouterWithHono } from "convex-helpers/server/hono";
+import { makeFunctionReference } from "convex/server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 
 import { api, internal } from "./_generated/api";
-import { makeFunctionReference } from "convex/server";
 import type { ActionCtx } from "./_generated/server";
 import { getWhatsNewEntry, listPublicChangelog } from "./lib/changelogIntake";
-import { getClientIpAddress, IP_RATE_LIMIT } from "./lib/projectKeyAuthorization";
 import { handleMcpRequest } from "./lib/mcpServer";
+import { validateWishAppBaseUrl } from "./lib/linearConnection";
+import { getClientIpAddress, IP_RATE_LIMIT } from "./lib/projectKeyAuthorization";
 import { toPublicProject } from "./lib/projectPublic";
 import { createPublicError, publicErrorJson, toPublicErrorResponse } from "./lib/publicErrors";
 import {
@@ -33,6 +34,40 @@ app.all("/mcp", async (c) => {
   } catch (error) {
     return publicErrorJson(c, toPublicErrorResponse(error));
   }
+});
+
+app.get("/work-trackers/linear/callback", async (c) => {
+  c.header("Cache-Control", "no-store");
+  c.header("Referrer-Policy", "no-referrer");
+  let appBaseUrl: string;
+  try {
+    appBaseUrl = validateWishAppBaseUrl(process.env.WISH_APP_BASE_URL?.trim() ?? "");
+  } catch {
+    return c.text("Linear callback is not configured", 500);
+  }
+
+  let result;
+  try {
+    result = await c.env.runAction(
+      internal.linearWorkTrackerOAuth.completeLinearOAuthInternal,
+      {
+        code: c.req.query("code") ?? "",
+        state: c.req.query("state") ?? "",
+        providerError: c.req.query("error"),
+      },
+    );
+  } catch {
+    result = { ok: false as const, errorCode: "invalid_callback" };
+  }
+  const redirectUrl = new URL(
+    result.projectId && result.projectSlug
+      ? `/dashboard/project/${encodeURIComponent(result.projectId)}/${encodeURIComponent(result.projectSlug)}/requests`
+      : "/dashboard",
+    appBaseUrl,
+  );
+  redirectUrl.searchParams.set("settings", "work-trackers");
+  redirectUrl.searchParams.set("linear", result.ok ? "authorized" : result.errorCode);
+  return c.redirect(redirectUrl.toString(), 303);
 });
 
 // The project API authenticates with public client keys, so browser embeds

--- a/packages/convex-backend/convex/lib/linearConnection.test.ts
+++ b/packages/convex-backend/convex/lib/linearConnection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { validateLinearRedirectUri, validateWishAppBaseUrl } from "./linearConnection";
+
+describe("Linear connection configuration", () => {
+  it("accepts only fixed callback and app origins", () => {
+    expect(validateWishAppBaseUrl("https://wish.example.com/")).toBe("https://wish.example.com");
+    expect(validateWishAppBaseUrl("http://localhost:3000/")).toBe("http://localhost:3000");
+    expect(() => validateWishAppBaseUrl("ftp://localhost/")).toThrow("Wish app base URL is invalid");
+    expect(() => validateWishAppBaseUrl("https://wish.example.com/path")).toThrow(
+      "Wish app base URL is invalid",
+    );
+    expect(
+      validateLinearRedirectUri("https://api.example.com/work-trackers/linear/callback"),
+    ).toBe("https://api.example.com/work-trackers/linear/callback");
+    expect(() => validateLinearRedirectUri("https://evil.example.com/callback")).toThrow(
+      "Linear OAuth redirect URI is invalid",
+    );
+  });
+});

--- a/packages/convex-backend/convex/lib/linearConnection.ts
+++ b/packages/convex-backend/convex/lib/linearConnection.ts
@@ -1,0 +1,120 @@
+import { validateWorkTrackerEncryptionKey } from "./workTrackerSecrets";
+
+export const LINEAR_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+export const LINEAR_AUTHORIZED_SETUP_TTL_MS = 30 * 60 * 1000;
+export const LINEAR_REFRESH_EARLY_MS = 5 * 60 * 1000;
+export const LINEAR_CREDENTIAL_LEASE_MS = 30 * 1000;
+
+export function validateLinearRedirectUri(value: string) {
+  try {
+    const url = new URL(value);
+    const localHttp = url.protocol === "http:" && url.hostname === "localhost";
+    if (
+      (url.protocol !== "https:" && !localHttp) ||
+      url.pathname !== "/work-trackers/linear/callback" ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    ) {
+      throw new Error();
+    }
+    return url.toString();
+  } catch {
+    throw new Error("Linear OAuth redirect URI is invalid");
+  }
+}
+
+export function validateWishAppBaseUrl(value: string) {
+  try {
+    const url = new URL(value);
+    const validProtocol =
+      url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "localhost");
+    if (
+      !validProtocol ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    ) {
+      throw new Error();
+    }
+    return url.origin;
+  } catch {
+    throw new Error("Wish app base URL is invalid");
+  }
+}
+
+export function getLinearConfig() {
+  const clientId = process.env.LINEAR_CLIENT_ID?.trim();
+  const clientSecret = process.env.LINEAR_CLIENT_SECRET?.trim();
+  const redirectUri = process.env.LINEAR_REDIRECT_URI?.trim();
+  const encryptionKey = process.env.WORK_TRACKER_ENCRYPTION_KEY?.trim();
+  if (!clientId || !clientSecret || !redirectUri || !encryptionKey) {
+    throw new Error("Linear OAuth is not configured");
+  }
+  validateWishAppBaseUrl(process.env.WISH_APP_BASE_URL?.trim() ?? "");
+  return {
+    clientId,
+    clientSecret,
+    redirectUri: validateLinearRedirectUri(redirectUri),
+    encryptionKey: validateWorkTrackerEncryptionKey(encryptionKey),
+  };
+}
+
+export function getWorkTrackerEncryptionKey() {
+  const encryptionKey = process.env.WORK_TRACKER_ENCRYPTION_KEY?.trim();
+  if (!encryptionKey) throw new Error("Work Tracker encryption key is not configured");
+  return validateWorkTrackerEncryptionKey(encryptionKey);
+}
+
+export function isLinearConfigured() {
+  try {
+    getLinearConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseStoredCredentials(value: string) {
+  try {
+    const credentials = JSON.parse(value) as Record<string, unknown>;
+    if (
+      typeof credentials.accessToken === "string" &&
+      credentials.accessToken.length > 0 &&
+      typeof credentials.refreshToken === "string" &&
+      credentials.refreshToken.length > 0 &&
+      typeof credentials.expiresAt === "number" &&
+      Number.isSafeInteger(credentials.expiresAt) &&
+      credentials.expiresAt > 0 &&
+      Array.isArray(credentials.scopes) &&
+      credentials.scopes.every((scope) => typeof scope === "string") &&
+      credentials.scopes.includes("read") &&
+      credentials.scopes.includes("issues:create")
+    ) {
+      return {
+        accessToken: credentials.accessToken,
+        refreshToken: credentials.refreshToken,
+        expiresAt: credentials.expiresAt,
+        scopes: credentials.scopes as string[],
+      };
+    }
+  } catch {
+    // Use the stable error below without leaking secret contents.
+  }
+  throw new Error("Invalid stored Linear credentials");
+}
+
+export function serializeCredentials(
+  credentials: { accessToken: string; refreshToken: string; expiresIn: number; scopes: string[] },
+  now: number,
+) {
+  return JSON.stringify({
+    accessToken: credentials.accessToken,
+    refreshToken: credentials.refreshToken,
+    expiresAt: now + credentials.expiresIn * 1000,
+    scopes: credentials.scopes,
+  });
+}

--- a/packages/convex-backend/convex/lib/linearOAuth.test.ts
+++ b/packages/convex-backend/convex/lib/linearOAuth.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  buildLinearAuthorizationUrl,
+  createLinearOAuthState,
+  hashLinearOAuthState,
+  parseLinearDiscoveryPage,
+  parseLinearTokenResponse,
+  readBoundedJson,
+  refreshLinearCredentials,
+  revokeLinearCredentials,
+} from "./linearOAuth";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Linear OAuth", () => {
+  it("builds the minimum app-actor authorization request", async () => {
+    const state = createLinearOAuthState();
+    const secondState = createLinearOAuthState();
+    const url = new URL(
+      buildLinearAuthorizationUrl({
+        clientId: "linear-client",
+        redirectUri: "https://api.example.com/work-trackers/linear/callback",
+        state,
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe("https://linear.app/oauth/authorize");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      actor: "app",
+      client_id: "linear-client",
+      redirect_uri: "https://api.example.com/work-trackers/linear/callback",
+      response_type: "code",
+      scope: "read,issues:create",
+      state,
+    });
+    expect(state).not.toBe(secondState);
+    expect(await hashLinearOAuthState(state)).toBe(await hashLinearOAuthState(state));
+  });
+
+  it("validates token and discovery responses before persistence", () => {
+    expect(
+      parseLinearTokenResponse({
+        access_token: "access",
+        refresh_token: "refresh",
+        expires_in: 86_400,
+        scope: "read issues:create",
+        token_type: "Bearer",
+      }),
+    ).toMatchObject({ accessToken: "access", refreshToken: "refresh", expiresIn: 86_400 });
+
+    expect(() => parseLinearTokenResponse({ access_token: "access" })).toThrow(
+      "Invalid Linear token response",
+    );
+    expect(() =>
+      parseLinearTokenResponse({
+        access_token: "access",
+        refresh_token: "refresh",
+        expires_in: Number.MAX_SAFE_INTEGER,
+        scope: "read issues:create",
+        token_type: "Bearer",
+      }),
+    ).toThrow("Invalid Linear token response");
+
+    expect(
+      parseLinearDiscoveryPage({
+        data: {
+          organization: { id: "org", name: "Acme", urlKey: "acme" },
+          teams: {
+            nodes: [{ id: "team", key: "ENG", name: "Engineering" }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      }),
+    ).toEqual({
+      organization: { id: "org", name: "Acme", urlKey: "acme" },
+      teams: [{ id: "team", key: "ENG", name: "Engineering" }],
+      hasNextPage: false,
+      endCursor: undefined,
+    });
+
+    expect(() => parseLinearDiscoveryPage({ data: { teams: { nodes: [] } } })).toThrow(
+      "Invalid Linear discovery response",
+    );
+  });
+
+  it("bounds declared and chunked response bodies", async () => {
+    await expect(
+      readBoundedJson(
+        new Response("{}", { headers: { "content-length": "1000001" } }),
+      ),
+    ).rejects.toThrow("Linear response exceeded the size limit");
+
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1_000_001));
+        controller.close();
+      },
+    });
+    await expect(readBoundedJson(new Response(body))).rejects.toThrow(
+      "Linear response exceeded the size limit",
+    );
+  });
+
+  it("distinguishes invalid credentials from transient token and revoke failures", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+      )
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(new Response(null, { status: 429 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      refreshLinearCredentials({
+        clientId: "client",
+        clientSecret: "secret",
+        refreshToken: "invalid",
+      }),
+    ).rejects.toThrow("Linear authorization is invalid");
+    await expect(
+      refreshLinearCredentials({
+        clientId: "client",
+        clientSecret: "secret",
+        refreshToken: "valid",
+      }),
+    ).rejects.toThrow("Linear token request failed");
+    await expect(revokeLinearCredentials("already-revoked")).resolves.toBeUndefined();
+    await expect(revokeLinearCredentials("rate-limited")).rejects.toThrow(
+      "Linear credential revocation failed",
+    );
+  });
+});

--- a/packages/convex-backend/convex/lib/linearOAuth.ts
+++ b/packages/convex-backend/convex/lib/linearOAuth.ts
@@ -1,0 +1,280 @@
+const LINEAR_AUTHORIZE_URL = "https://linear.app/oauth/authorize";
+const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
+const LINEAR_REVOKE_URL = "https://api.linear.app/oauth/revoke";
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+const LINEAR_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 1_000_000;
+const MAX_TEAM_PAGES = 10;
+const MAX_TEAMS = 500;
+const MAX_TOKEN_LIFETIME_SECONDS = 365 * 24 * 60 * 60;
+
+const discoveryQuery = `query ConfigureLinearConnection($first: Int!, $after: String) {
+  organization { id name urlKey }
+  teams(first: $first, after: $after) {
+    nodes { id key name }
+    pageInfo { hasNextPage endCursor }
+  }
+}`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function encodeBase64Url(value: Uint8Array) {
+  return btoa(String.fromCharCode(...value))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+export function createLinearOAuthState() {
+  return encodeBase64Url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+export async function hashLinearOAuthState(state: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(state));
+  return encodeBase64Url(new Uint8Array(digest));
+}
+
+export function buildLinearAuthorizationUrl(args: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  promptForWorkspace?: boolean;
+}) {
+  const url = new URL(LINEAR_AUTHORIZE_URL);
+  url.search = new URLSearchParams({
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    response_type: "code",
+    scope: "read,issues:create",
+    state: args.state,
+    actor: "app",
+  }).toString();
+  if (args.promptForWorkspace) {
+    url.searchParams.set("prompt", "consent");
+  }
+  return url.toString();
+}
+
+export function parseLinearTokenResponse(value: unknown) {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Linear token response");
+  }
+
+  const accessToken = readString(value.access_token);
+  const refreshToken = readString(value.refresh_token);
+  const tokenType = readString(value.token_type);
+  const scope = readString(value.scope);
+  const expiresIn = value.expires_in;
+  const scopes = scope?.split(/[ ,]+/).filter(Boolean) ?? [];
+
+  if (
+    !accessToken ||
+    !refreshToken ||
+    tokenType?.toLowerCase() !== "bearer" ||
+    typeof expiresIn !== "number" ||
+    !Number.isSafeInteger(expiresIn) ||
+    expiresIn <= 0 ||
+    expiresIn > MAX_TOKEN_LIFETIME_SECONDS ||
+    !scopes.includes("read") ||
+    !scopes.includes("issues:create")
+  ) {
+    throw new Error("Invalid Linear token response");
+  }
+
+  return { accessToken, refreshToken, expiresIn, scopes };
+}
+
+export function parseLinearDiscoveryPage(value: unknown) {
+  if (!isRecord(value) || (Array.isArray(value.errors) && value.errors.length > 0)) {
+    throw new Error("Invalid Linear discovery response");
+  }
+
+  const data = value.data;
+  if (!isRecord(data) || !isRecord(data.organization) || !isRecord(data.teams)) {
+    throw new Error("Invalid Linear discovery response");
+  }
+
+  const organizationId = readString(data.organization.id);
+  const organizationName = readString(data.organization.name);
+  const organizationUrlKey = readString(data.organization.urlKey);
+  const nodes = data.teams.nodes;
+  const pageInfo = data.teams.pageInfo;
+  if (
+    !organizationId ||
+    !organizationName ||
+    !organizationUrlKey ||
+    !Array.isArray(nodes) ||
+    !isRecord(pageInfo) ||
+    typeof pageInfo.hasNextPage !== "boolean"
+  ) {
+    throw new Error("Invalid Linear discovery response");
+  }
+
+  const teams = nodes.map((node) => {
+    if (!isRecord(node)) {
+      throw new Error("Invalid Linear discovery response");
+    }
+    const id = readString(node.id);
+    const key = readString(node.key);
+    const name = readString(node.name);
+    if (!id || !key || !name) {
+      throw new Error("Invalid Linear discovery response");
+    }
+    return { id, key, name };
+  });
+  const endCursor = readString(pageInfo.endCursor) ?? undefined;
+  if (pageInfo.hasNextPage && !endCursor) {
+    throw new Error("Invalid Linear discovery response");
+  }
+
+  return {
+    organization: { id: organizationId, name: organizationName, urlKey: organizationUrlKey },
+    teams,
+    hasNextPage: pageInfo.hasNextPage,
+    endCursor,
+  };
+}
+
+export async function readBoundedJson(response: Response) {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+    throw new Error("Linear response exceeded the size limit");
+  }
+
+  if (!response.body) {
+    throw new Error("Linear returned an invalid response");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let byteLength = 0;
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    byteLength += value.byteLength;
+    if (byteLength > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error("Linear response exceeded the size limit");
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("Linear returned an invalid response");
+  }
+}
+
+async function requestLinearToken(params: URLSearchParams) {
+  const response = await fetch(LINEAR_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: params,
+    signal: AbortSignal.timeout(LINEAR_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    let errorCode: string | null = null;
+    try {
+      const body = await readBoundedJson(response);
+      errorCode = isRecord(body) ? readString(body.error) : null;
+    } catch {
+      // The fixed error below is sufficient for transient and malformed failures.
+    }
+    if ((response.status === 400 || response.status === 401) && errorCode === "invalid_grant") {
+      throw new Error("Linear authorization is invalid");
+    }
+    throw new Error("Linear token request failed");
+  }
+  return parseLinearTokenResponse(await readBoundedJson(response));
+}
+
+export async function exchangeLinearAuthorizationCode(args: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+}) {
+  return await requestLinearToken(
+    new URLSearchParams({
+      client_id: args.clientId,
+      client_secret: args.clientSecret,
+      redirect_uri: args.redirectUri,
+      code: args.code,
+      grant_type: "authorization_code",
+    }),
+  );
+}
+
+export async function refreshLinearCredentials(args: {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}) {
+  return await requestLinearToken(
+    new URLSearchParams({
+      client_id: args.clientId,
+      client_secret: args.clientSecret,
+      refresh_token: args.refreshToken,
+      grant_type: "refresh_token",
+    }),
+  );
+}
+
+export async function revokeLinearCredentials(refreshToken: string) {
+  const response = await fetch(LINEAR_REVOKE_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ token: refreshToken, token_type_hint: "refresh_token" }),
+    signal: AbortSignal.timeout(LINEAR_TIMEOUT_MS),
+  });
+  if (!response.ok && response.status !== 400 && response.status !== 401) {
+    throw new Error("Linear credential revocation failed");
+  }
+}
+
+export async function discoverLinearWorkspace(accessToken: string) {
+  let after: string | undefined;
+  let organization: ReturnType<typeof parseLinearDiscoveryPage>["organization"] | undefined;
+  const teams: ReturnType<typeof parseLinearDiscoveryPage>["teams"] = [];
+
+  for (let page = 0; page < MAX_TEAM_PAGES; page += 1) {
+    const response = await fetch(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query: discoveryQuery, variables: { first: 50, after } }),
+      signal: AbortSignal.timeout(LINEAR_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(
+        response.status === 401 ? "Linear authorization is invalid" : "Linear discovery failed",
+      );
+    }
+
+    const result = parseLinearDiscoveryPage(await readBoundedJson(response));
+    if (organization && organization.id !== result.organization.id) {
+      throw new Error("Linear returned an inconsistent workspace");
+    }
+    organization = result.organization;
+    teams.push(...result.teams);
+    if (teams.length > MAX_TEAMS) {
+      throw new Error("Linear returned too many teams");
+    }
+    if (!result.hasNextPage) {
+      return { organization, teams };
+    }
+    after = result.endCursor;
+  }
+
+  throw new Error("Linear team pagination exceeded the limit");
+}

--- a/packages/convex-backend/convex/lib/workTrackerConnection.ts
+++ b/packages/convex-backend/convex/lib/workTrackerConnection.ts
@@ -1,0 +1,6 @@
+export function isWorkTrackerCredentialLeaseActive(
+  lease: { expiresAt: number } | undefined,
+  now: number,
+) {
+  return Boolean(lease && lease.expiresAt > now);
+}

--- a/packages/convex-backend/convex/lib/workTrackerGuards.ts
+++ b/packages/convex-backend/convex/lib/workTrackerGuards.ts
@@ -1,0 +1,19 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+export async function assertNoBlockingLinearHandoffs(
+  ctx: MutationCtx,
+  projectId: Id<"projects">,
+) {
+  for (const state of ["pending", "unknown"] as const) {
+    const handoff = await ctx.db
+      .query("workItemHandoffs")
+      .withIndex("by_project_provider_state", (q) =>
+        q.eq("projectId", projectId).eq("provider", "linear").eq("lifecycle.state", state),
+      )
+      .first();
+    if (handoff) {
+      throw new Error("Work Tracker change is blocked while a Handoff is unresolved");
+    }
+  }
+}

--- a/packages/convex-backend/convex/lib/workTrackerSecrets.ts
+++ b/packages/convex-backend/convex/lib/workTrackerSecrets.ts
@@ -14,6 +14,11 @@ function decodeEncryptionKey(value: string) {
   throw new Error("Work Tracker encryption key must be 32 bytes encoded as base64");
 }
 
+export function validateWorkTrackerEncryptionKey(value: string) {
+  decodeEncryptionKey(value);
+  return value;
+}
+
 function encodeBase64(value: Uint8Array) {
   return btoa(String.fromCharCode(...value));
 }

--- a/packages/convex-backend/convex/lib/workTrackerTypes.ts
+++ b/packages/convex-backend/convex/lib/workTrackerTypes.ts
@@ -12,23 +12,70 @@ const encryptedCredentialsValidator = v.object({
   iv: v.string(),
 });
 
+const linearOrganizationValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  urlKey: v.string(),
+});
+
+const linearTeamValidator = v.object({
+  id: v.string(),
+  key: v.string(),
+  name: v.string(),
+});
+
 export const workTrackerConnectionDataValidator = v.object({
   provider: v.literal("linear"),
   organizationId: v.string(),
   organizationName: v.string(),
+  organizationUrlKey: v.string(),
   teamId: v.string(),
+  teamKey: v.string(),
   teamName: v.string(),
   encryptedCredentials: encryptedCredentialsValidator,
-});
-
-export const workTrackerOAuthSetupDataValidator = v.object({
-  provider: v.literal("linear"),
-  authorization: v.optional(
+  credentialLease: v.optional(
+    v.object({
+      id: v.string(),
+      expiresAt: v.number(),
+    }),
+  ),
+  pendingRevocation: v.optional(
     v.object({
       encryptedCredentials: encryptedCredentialsValidator,
+      retryAt: v.number(),
     }),
   ),
 });
+
+export const workTrackerOAuthSetupDataValidator = v.union(
+  v.object({
+    provider: v.literal("linear"),
+    stage: v.literal("pending"),
+    redirectUri: v.string(),
+  }),
+  v.object({
+    provider: v.literal("linear"),
+    stage: v.literal("exchanged"),
+    redirectUri: v.string(),
+    encryptedCredentials: encryptedCredentialsValidator,
+  }),
+  v.object({
+    provider: v.literal("linear"),
+    stage: v.literal("ready"),
+    redirectUri: v.string(),
+    encryptedCredentials: encryptedCredentialsValidator,
+    authorization: v.object({
+      organization: linearOrganizationValidator,
+      teams: v.array(linearTeamValidator),
+    }),
+  }),
+  v.object({
+    provider: v.literal("linear"),
+    stage: v.literal("discarding"),
+    redirectUri: v.string(),
+    encryptedCredentials: encryptedCredentialsValidator,
+  }),
+);
 
 export const workItemHandoffRecoveryValidator = v.object({
   provider: v.literal("linear"),

--- a/packages/convex-backend/convex/linearWorkTrackerCleanup.ts
+++ b/packages/convex-backend/convex/linearWorkTrackerCleanup.ts
@@ -1,0 +1,152 @@
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { internalAction, internalMutation, internalQuery } from "./_generated/server";
+import { getWorkTrackerEncryptionKey, parseStoredCredentials } from "./lib/linearConnection";
+import { revokeLinearCredentials } from "./lib/linearOAuth";
+import { decryptWorkTrackerSecret } from "./lib/workTrackerSecrets";
+
+const REVOCATION_RETRY_MS = 5 * 60 * 1000;
+
+export const getExpiredLinearSetupsInternal = internalQuery({
+  args: { now: v.number() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("workTrackerOAuthSetups")
+      .withIndex("by_expires_at", (q) => q.lt("expiresAt", args.now))
+      .take(10);
+  },
+});
+
+export const deleteExpiredLinearSetupInternal = internalMutation({
+  args: { setupId: v.id("workTrackerOAuthSetups"), now: v.number() },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db.get(args.setupId);
+    if (setup && setup.provider === "linear" && setup.expiresAt < args.now) {
+      await ctx.db.delete(setup._id);
+    }
+  },
+});
+
+export const rescheduleLinearSetupRevocationInternal = internalMutation({
+  args: { setupId: v.id("workTrackerOAuthSetups"), retryAt: v.number() },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db.get(args.setupId);
+    if (setup && setup.provider === "linear" && setup.data.stage !== "pending") {
+      await ctx.db.patch(setup._id, { expiresAt: args.retryAt });
+    }
+  },
+});
+
+export const getPendingLinearRevocationsInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_pending_revocation", (q) =>
+        q
+          .gt("data.pendingRevocation.retryAt", 0)
+          .lte("data.pendingRevocation.retryAt", Date.now()),
+      )
+      .take(10);
+  },
+});
+
+export const reschedulePendingLinearRevocationInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    ciphertext: v.string(),
+    retryAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (
+      connection?.data.pendingRevocation?.encryptedCredentials.ciphertext !== args.ciphertext
+    ) {
+      return;
+    }
+    await ctx.db.patch(connection._id, {
+      data: {
+        ...connection.data,
+        pendingRevocation: { ...connection.data.pendingRevocation, retryAt: args.retryAt },
+      },
+    });
+  },
+});
+
+export const cleanupExpiredLinearSetupsInternal = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const setups: Doc<"workTrackerOAuthSetups">[] = await ctx.runQuery(
+      internal.linearWorkTrackerCleanup.getExpiredLinearSetupsInternal,
+      { now },
+    );
+    for (const setup of setups) {
+      const encrypted = setup.data.stage === "pending" ? undefined : setup.data.encryptedCredentials;
+      let revoked = !encrypted;
+      if (encrypted) {
+        try {
+          const credentials = parseStoredCredentials(
+            await decryptWorkTrackerSecret(encrypted, getWorkTrackerEncryptionKey()),
+          );
+          await revokeLinearCredentials(credentials.refreshToken);
+          revoked = true;
+        } catch (error) {
+          console.error("Expired Linear setup revocation failed", {
+            setupId: setup._id,
+            message: error instanceof Error ? error.message.slice(0, 200) : "Unknown error",
+          });
+          await ctx.runMutation(
+            internal.linearWorkTrackerCleanup.rescheduleLinearSetupRevocationInternal,
+            { setupId: setup._id, retryAt: now + REVOCATION_RETRY_MS },
+          );
+        }
+      }
+      if (revoked) {
+        await ctx.runMutation(
+          internal.linearWorkTrackerCleanup.deleteExpiredLinearSetupInternal,
+          { setupId: setup._id, now },
+        );
+      }
+    }
+  },
+});
+
+export const cleanupPendingLinearRevocationsInternal = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const connections: Doc<"workTrackerConnections">[] = await ctx.runQuery(
+      internal.linearWorkTrackerCleanup.getPendingLinearRevocationsInternal,
+      {},
+    );
+    for (const connection of connections) {
+      const encrypted = connection.data.pendingRevocation?.encryptedCredentials;
+      if (!encrypted) continue;
+      try {
+        const credentials = parseStoredCredentials(
+          await decryptWorkTrackerSecret(encrypted, getWorkTrackerEncryptionKey()),
+        );
+        await revokeLinearCredentials(credentials.refreshToken);
+        await ctx.runMutation(
+          internal.workTrackerConnections.clearLinearPendingRevocationInternal,
+          { connectionId: connection._id, ciphertext: encrypted.ciphertext },
+        );
+      } catch (error) {
+        console.error("Pending Linear credential revocation failed", {
+          connectionId: connection._id,
+          message: error instanceof Error ? error.message.slice(0, 200) : "Unknown error",
+        });
+        await ctx.runMutation(
+          internal.linearWorkTrackerCleanup.reschedulePendingLinearRevocationInternal,
+          {
+            connectionId: connection._id,
+            ciphertext: encrypted.ciphertext,
+            retryAt: Date.now() + REVOCATION_RETRY_MS,
+          },
+        );
+      }
+    }
+  },
+});

--- a/packages/convex-backend/convex/linearWorkTrackerOAuth.ts
+++ b/packages/convex-backend/convex/linearWorkTrackerOAuth.ts
@@ -1,0 +1,351 @@
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import {
+  action,
+  internalAction,
+  internalMutation,
+} from "./_generated/server";
+import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
+import {
+  getLinearConfig,
+  getWorkTrackerEncryptionKey,
+  LINEAR_AUTHORIZED_SETUP_TTL_MS,
+  LINEAR_OAUTH_STATE_TTL_MS,
+  parseStoredCredentials,
+  serializeCredentials,
+  validateLinearRedirectUri,
+} from "./lib/linearConnection";
+import {
+  buildLinearAuthorizationUrl,
+  createLinearOAuthState,
+  discoverLinearWorkspace,
+  exchangeLinearAuthorizationCode,
+  hashLinearOAuthState,
+  revokeLinearCredentials,
+} from "./lib/linearOAuth";
+import {
+  decryptWorkTrackerSecret,
+  encryptWorkTrackerSecret,
+} from "./lib/workTrackerSecrets";
+
+export const createLinearOAuthSetupInternal = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    stateHash: v.string(),
+    redirectUri: v.string(),
+    createdAt: v.number(),
+    expiresAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const existingSetup = await ctx.db
+      .query("workTrackerOAuthSetups")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+    if (existingSetup && existingSetup.data.stage !== "pending") {
+      throw new Error("Discard the existing Linear authorization before starting again");
+    }
+    if (existingSetup) {
+      await ctx.db.delete(existingSetup._id);
+    }
+
+    return await ctx.db.insert("workTrackerOAuthSetups", {
+      projectId: args.projectId,
+      provider: "linear",
+      stateHash: args.stateHash,
+      data: {
+        provider: "linear",
+        stage: "pending",
+        redirectUri: validateLinearRedirectUri(args.redirectUri),
+      },
+      createdBy: user._id,
+      createdAt: args.createdAt,
+      expiresAt: args.expiresAt,
+    });
+  },
+});
+
+export const beginLinearOAuth = action({
+  args: {
+    projectId: v.id("projects"),
+    promptForWorkspace: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args): Promise<{ authorizationUrl: string }> => {
+    const config = getLinearConfig();
+    const state = createLinearOAuthState();
+    const now = Date.now();
+    await ctx.runMutation(internal.linearWorkTrackerOAuth.createLinearOAuthSetupInternal, {
+      projectId: args.projectId,
+      stateHash: await hashLinearOAuthState(state),
+      redirectUri: config.redirectUri,
+      createdAt: now,
+      expiresAt: now + LINEAR_OAUTH_STATE_TTL_MS,
+    });
+
+    return {
+      authorizationUrl: buildLinearAuthorizationUrl({
+        clientId: config.clientId,
+        redirectUri: config.redirectUri,
+        state,
+        promptForWorkspace: args.promptForWorkspace,
+      }),
+    };
+  },
+});
+
+export const claimLinearOAuthSetupInternal = internalMutation({
+  args: { stateHash: v.string(), now: v.number() },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db
+      .query("workTrackerOAuthSetups")
+      .withIndex("by_state_hash", (q) => q.eq("stateHash", args.stateHash))
+      .unique();
+    if (!setup || setup.provider !== "linear" || setup.consumedAt || setup.expiresAt <= args.now) {
+      throw new Error("Invalid or expired Linear OAuth state");
+    }
+    const project = await ctx.db.get(setup.projectId);
+    if (!project || project.user !== setup.createdBy) {
+      throw new Error("Invalid or expired Linear OAuth state");
+    }
+
+    await ctx.db.patch(setup._id, { consumedAt: args.now });
+    const redirectUri = setup.data.redirectUri;
+    return {
+      setupId: setup._id,
+      projectId: project._id,
+      projectSlug: project.projectSlug ?? "project",
+      redirectUri: validateLinearRedirectUri(redirectUri),
+    };
+  },
+});
+
+export const saveLinearOAuthCredentialsInternal = internalMutation({
+  args: {
+    setupId: v.id("workTrackerOAuthSetups"),
+    encryptedCredentials: v.object({ ciphertext: v.string(), iv: v.string() }),
+    expiresAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db.get(args.setupId);
+    if (
+      !setup ||
+      setup.provider !== "linear" ||
+      !setup.consumedAt ||
+      setup.data.stage !== "pending"
+    ) {
+      throw new Error("Linear OAuth setup is no longer available");
+    }
+    await ctx.db.patch(setup._id, {
+      data: {
+        provider: "linear",
+        stage: "exchanged",
+        redirectUri: setup.data.redirectUri,
+        encryptedCredentials: args.encryptedCredentials,
+      },
+      expiresAt: args.expiresAt,
+    });
+  },
+});
+
+export const saveLinearOAuthAuthorizationInternal = internalMutation({
+  args: {
+    setupId: v.id("workTrackerOAuthSetups"),
+    organization: v.object({ id: v.string(), name: v.string(), urlKey: v.string() }),
+    teams: v.array(v.object({ id: v.string(), key: v.string(), name: v.string() })),
+  },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db.get(args.setupId);
+    if (!setup?.consumedAt || setup.data.stage !== "exchanged") {
+      throw new Error("Linear OAuth setup is no longer available");
+    }
+    await ctx.db.patch(setup._id, {
+      data: {
+        ...setup.data,
+        stage: "ready",
+        authorization: { organization: args.organization, teams: args.teams },
+      },
+    });
+  },
+});
+
+export const disposeLinearOAuthSetupInternal = internalMutation({
+  args: { setupId: v.id("workTrackerOAuthSetups"), deleteSetup: v.boolean(), now: v.number() },
+  handler: async (ctx, args) => {
+    const setup = await ctx.db.get(args.setupId);
+    if (!setup) return;
+    if (args.deleteSetup) {
+      await ctx.db.delete(setup._id);
+    } else {
+      await ctx.db.patch(setup._id, { expiresAt: args.now });
+    }
+  },
+});
+
+export const completeLinearOAuthInternal = internalAction({
+  args: { code: v.string(), state: v.string(), providerError: v.optional(v.string()) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    | {
+        ok: true;
+        projectId: Id<"projects">;
+        projectSlug: string;
+        setupId: Id<"workTrackerOAuthSetups">;
+      }
+    | {
+        ok: false;
+        errorCode: string;
+        projectId?: Id<"projects">;
+        projectSlug?: string;
+      }
+  > => {
+    if (args.state.length < 32 || args.state.length > 256) {
+      return { ok: false, errorCode: "invalid_callback" };
+    }
+
+    let claimed:
+      | {
+          setupId: Id<"workTrackerOAuthSetups">;
+          projectId: Id<"projects">;
+          projectSlug: string;
+          redirectUri: string;
+        }
+      | undefined;
+    let refreshToken: string | undefined;
+    let credentialsPersisted = false;
+    let stage = "state";
+    try {
+      const claimedSetup = await ctx.runMutation(
+        internal.linearWorkTrackerOAuth.claimLinearOAuthSetupInternal,
+        { stateHash: await hashLinearOAuthState(args.state), now: Date.now() },
+      );
+      claimed = claimedSetup;
+      if (args.providerError || !args.code || args.code.length > 4096) {
+        await ctx.runMutation(internal.linearWorkTrackerOAuth.disposeLinearOAuthSetupInternal, {
+          setupId: claimedSetup.setupId,
+          deleteSetup: true,
+          now: Date.now(),
+        });
+        return {
+          ok: false,
+          errorCode: args.providerError ? "authorization_denied" : "invalid_callback",
+          ...claimedSetup,
+        };
+      }
+      stage = "exchange";
+      const config = getLinearConfig();
+      const token = await exchangeLinearAuthorizationCode({
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+        redirectUri: claimedSetup.redirectUri,
+        code: args.code,
+      });
+      refreshToken = token.refreshToken;
+      stage = "persistence";
+      const now = Date.now();
+      const encryptedCredentials = await encryptWorkTrackerSecret(
+        serializeCredentials(token, now),
+        config.encryptionKey,
+      );
+      await ctx.runMutation(internal.linearWorkTrackerOAuth.saveLinearOAuthCredentialsInternal, {
+        setupId: claimedSetup.setupId,
+        encryptedCredentials,
+        expiresAt: now + LINEAR_AUTHORIZED_SETUP_TTL_MS,
+      });
+      credentialsPersisted = true;
+      stage = "discovery";
+      const discovery = await discoverLinearWorkspace(token.accessToken);
+      stage = "persistence";
+      await ctx.runMutation(internal.linearWorkTrackerOAuth.saveLinearOAuthAuthorizationInternal, {
+        setupId: claimedSetup.setupId,
+        organization: discovery.organization,
+        teams: discovery.teams,
+      });
+      return { ok: true, ...claimedSetup };
+    } catch (error) {
+      let revoked = false;
+      if (refreshToken) {
+        try {
+          await revokeLinearCredentials(refreshToken);
+          revoked = true;
+        } catch {
+          // Persisted credentials are left for the cleanup job to retry.
+        }
+      }
+      if (claimed) {
+        await ctx.runMutation(internal.linearWorkTrackerOAuth.disposeLinearOAuthSetupInternal, {
+          setupId: claimed.setupId,
+          deleteSetup: !credentialsPersisted || revoked,
+          now: Date.now(),
+        });
+      }
+      console.error("Linear OAuth callback failed", {
+        stage,
+        setupId: claimed?.setupId,
+        message: error instanceof Error ? error.message.slice(0, 200) : "Unknown error",
+      });
+      return {
+        ok: false,
+        errorCode: stage === "state" ? "invalid_state" : `linear_${stage}_failed`,
+        projectId: claimed?.projectId,
+        projectSlug: claimed?.projectSlug,
+      };
+    }
+  },
+});
+
+export const claimLinearOAuthSetupDiscardInternal = internalMutation({
+  args: { projectId: v.id("projects"), setupId: v.id("workTrackerOAuthSetups") },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const setup = await ctx.db.get(args.setupId);
+    if (!setup || setup.projectId !== args.projectId || setup.provider !== "linear") {
+      return null;
+    }
+    if (setup.data.stage === "pending") {
+      await ctx.db.delete(setup._id);
+      return null;
+    }
+    await ctx.db.patch(setup._id, {
+      data: {
+        provider: "linear",
+        stage: "discarding",
+        redirectUri: setup.data.redirectUri,
+        encryptedCredentials: setup.data.encryptedCredentials,
+      },
+      expiresAt: Date.now(),
+    });
+    return {
+      encryptedCredentials: setup.data.encryptedCredentials,
+      setupId: setup._id,
+    };
+  },
+});
+
+export const discardLinearOAuthSetup = action({
+  args: { projectId: v.id("projects"), setupId: v.id("workTrackerOAuthSetups") },
+  handler: async (ctx, args): Promise<{ discarded: true }> => {
+    const setup = await ctx.runMutation(
+      internal.linearWorkTrackerOAuth.claimLinearOAuthSetupDiscardInternal,
+      args,
+    );
+    if (!setup) return { discarded: true };
+    const credentials = parseStoredCredentials(
+      await decryptWorkTrackerSecret(setup.encryptedCredentials, getWorkTrackerEncryptionKey()),
+    );
+    await revokeLinearCredentials(credentials.refreshToken);
+    await ctx.runMutation(internal.linearWorkTrackerOAuth.disposeLinearOAuthSetupInternal, {
+      setupId: setup.setupId,
+      deleteSetup: true,
+      now: Date.now(),
+    });
+    return { discarded: true };
+  },
+});

--- a/packages/convex-backend/convex/linearWorkTrackerSettings.ts
+++ b/packages/convex-backend/convex/linearWorkTrackerSettings.ts
@@ -1,0 +1,66 @@
+import { v } from "convex/values";
+
+import { query } from "./_generated/server";
+import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
+import { isLinearConfigured } from "./lib/linearConnection";
+
+export const getLinearSettings = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const connection = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+    const setup = await ctx.db
+      .query("workTrackerOAuthSetups")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+    const readySetup =
+      setup?.data.stage === "ready" && setup.expiresAt > Date.now()
+        ? {
+            id: setup._id,
+            expiresAt: setup.expiresAt,
+            authorization: setup.data.authorization,
+          }
+        : null;
+
+    return {
+      configured: isLinearConfigured(),
+      cleanupSetupId:
+        setup && setup.data.stage !== "pending" && !readySetup ? setup._id : null,
+      connection: connection
+        ? {
+            health: connection.health,
+            destinationLabel: connection.destinationLabel,
+            organization: {
+              id: connection.data.organizationId,
+              name: connection.data.organizationName,
+              urlKey: connection.data.organizationUrlKey,
+            },
+            team: {
+              id: connection.data.teamId,
+              key: connection.data.teamKey,
+              name: connection.data.teamName,
+            },
+          }
+        : null,
+      setup: readySetup
+        ? {
+            id: readySetup.id,
+            expiresAt: readySetup.expiresAt,
+            organization: readySetup.authorization.organization,
+            teams: readySetup.authorization.teams,
+            replacesWorkspace:
+              Boolean(connection) &&
+              connection?.data.organizationId !== readySetup.authorization.organization.id,
+          }
+        : null,
+    };
+  },
+});

--- a/packages/convex-backend/convex/projects.ts
+++ b/packages/convex-backend/convex/projects.ts
@@ -237,6 +237,22 @@ export const deleteProject = mutation({
       .query("changelogEntries")
       .withIndex("by_project", (q) => q.eq("projectId", args.id))
       .collect();
+    const workTrackerConnection = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project", (q) => q.eq("projectId", args.id))
+      .first();
+    const workTrackerSetup = await ctx.db
+      .query("workTrackerOAuthSetups")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.id).eq("provider", "linear"),
+      )
+      .unique();
+    if (
+      workTrackerConnection ||
+      (workTrackerSetup && workTrackerSetup.data.stage !== "pending")
+    ) {
+      throw new Error("Disconnect Work Trackers before deleting this project");
+    }
 
     await Promise.all(upvotes.map((upvote) => ctx.db.delete(upvote._id)));
     await Promise.all(comments.map((comment) => ctx.db.delete(comment._id)));
@@ -244,6 +260,7 @@ export const deleteProject = mutation({
     await Promise.all(statuses.map((status) => ctx.db.delete(status._id)));
     await Promise.all(apiKeys.map((apiKey) => ctx.db.delete(apiKey._id)));
     await Promise.all(changelogEntries.map((entry) => ctx.db.delete(entry._id)));
+    if (workTrackerSetup) await ctx.db.delete(workTrackerSetup._id);
 
     await ctx.db.delete(args.id);
   },

--- a/packages/convex-backend/convex/schema.ts
+++ b/packages/convex-backend/convex/schema.ts
@@ -130,7 +130,8 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_project", ["projectId"])
-    .index("by_project_provider", ["projectId", "provider"]),
+    .index("by_project_provider", ["projectId", "provider"])
+    .index("by_pending_revocation", ["data.pendingRevocation.retryAt"]),
 
   workTrackerOAuthSetups: defineTable({
     projectId: v.id("projects"),

--- a/packages/convex-backend/convex/workItemHandoffs.test.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.test.ts
@@ -30,6 +30,25 @@ describe("Work Item Handoff reservation", () => {
         status: statusId,
         project: projectId,
       });
+      await ctx.db.insert("workTrackerConnections", {
+        projectId,
+        provider: "linear",
+        health: "active",
+        destinationLabel: "Engineering",
+        data: {
+          provider: "linear",
+          organizationId: "org",
+          organizationName: "Workspace",
+          organizationUrlKey: "workspace",
+          teamId: "team",
+          teamKey: "ENG",
+          teamName: "Engineering",
+          encryptedCredentials: { ciphertext: "ciphertext", iv: "iv" },
+        },
+        createdBy: userId,
+        createdAt: 1,
+        updatedAt: 1,
+      });
       return { projectId, requestId };
     });
 

--- a/packages/convex-backend/convex/workItemHandoffs.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { internalMutation } from "./_generated/server";
 import { WORK_ITEM_HANDOFF_LEASE_MS } from "./lib/workItemHandoff";
+import { isWorkTrackerCredentialLeaseActive } from "./lib/workTrackerConnection";
 import { workTrackerProviderValidator } from "./lib/workTrackerTypes";
 
 export const reserveInternal = internalMutation({
@@ -27,6 +28,25 @@ export const reserveInternal = internalMutation({
     }
 
     const now = Date.now();
+    const connection = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", args.provider),
+      )
+      .unique();
+    if (
+      !connection ||
+      connection.health !== "active" ||
+      isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, now)
+    ) {
+      throw new Error("Work Tracker connection is not available");
+    }
+    if (connection.data.credentialLease) {
+      await ctx.db.patch(connection._id, {
+        data: { ...connection.data, credentialLease: undefined },
+      });
+    }
+
     const handoffId = await ctx.db.insert("workItemHandoffs", {
       projectId: args.projectId,
       requestId: args.requestId,

--- a/packages/convex-backend/convex/workTrackerConnections.test.ts
+++ b/packages/convex-backend/convex/workTrackerConnections.test.ts
@@ -1,0 +1,518 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vite-plus/test";
+
+import { api, internal } from "./_generated/api";
+import schema from "./schema";
+import { parseStoredCredentials } from "./lib/linearConnection";
+
+const modules = {
+  "./_generated/server.ts": () => import("./_generated/server"),
+  "./projects.ts": () => import("./projects"),
+  "./linearWorkTrackerSettings.ts": () => import("./linearWorkTrackerSettings"),
+  "./linearWorkTrackerOAuth.ts": () => import("./linearWorkTrackerOAuth"),
+  "./workItemHandoffs.ts": () => import("./workItemHandoffs"),
+  "./workTrackerConnections.ts": () => import("./workTrackerConnections"),
+};
+
+const encryptedCredentials = { ciphertext: "new-ciphertext", iv: "new-iv" };
+const oldEncryptedCredentials = { ciphertext: "old-ciphertext", iv: "old-iv" };
+
+async function seed() {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      name: "Owner",
+      tokenIdentifier: "owner-token",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      title: "Project",
+      user: userId,
+      projectSlug: "project",
+    });
+    const statusId = await ctx.db.insert("requestStatuses", {
+      name: "open",
+      displayName: "Open",
+      project: projectId,
+      type: "custom",
+    });
+    const requestId = await ctx.db.insert("requests", {
+      text: "Export reports",
+      clientId: "client",
+      status: statusId,
+      project: projectId,
+    });
+    const setupId = await ctx.db.insert("workTrackerOAuthSetups", {
+      projectId,
+      provider: "linear",
+      stateHash: "state",
+      data: {
+        provider: "linear",
+        stage: "ready",
+        redirectUri: "https://api.example.com/work-trackers/linear/callback",
+        encryptedCredentials,
+        authorization: {
+          organization: { id: "org-2", name: "New workspace", urlKey: "new" },
+          teams: [
+            { id: "team-2", key: "NEW", name: "New team" },
+            { id: "team-3", key: "OPS", name: "Operations" },
+          ],
+        },
+      },
+      createdBy: userId,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      consumedAt: 2,
+    });
+    const connectionId = await ctx.db.insert("workTrackerConnections", {
+      projectId,
+      provider: "linear",
+      health: "active",
+      destinationLabel: "Old team",
+      data: {
+        provider: "linear",
+        organizationId: "org-1",
+        organizationName: "Old workspace",
+        organizationUrlKey: "old",
+        teamId: "team-1",
+        teamKey: "OLD",
+        teamName: "Old team",
+        encryptedCredentials: oldEncryptedCredentials,
+      },
+      createdBy: userId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    return { connectionId, projectId, requestId, setupId };
+  });
+
+  return { ids, owner: t.withIdentity({ tokenIdentifier: "owner-token" }), t };
+}
+
+describe("Work Tracker connections", () => {
+  it("rejects malformed stored credentials", () => {
+    expect(() =>
+      parseStoredCredentials(
+        JSON.stringify({
+          accessToken: "access",
+          refreshToken: "refresh",
+          expiresAt: null,
+          scopes: ["read", "issues:create"],
+        }),
+      ),
+    ).toThrow("Invalid stored Linear credentials");
+    expect(() =>
+      parseStoredCredentials(
+        JSON.stringify({
+          accessToken: "access",
+          refreshToken: "refresh",
+          expiresAt: Date.now(),
+          scopes: ["read"],
+        }),
+      ),
+    ).toThrow("Invalid stored Linear credentials");
+  });
+
+  it("consumes OAuth state once and rejects expired state", async () => {
+    const { ids, t } = await seed();
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.setupId, { consumedAt: undefined, stateHash: "single-use" });
+    });
+
+    await expect(
+      t.mutation(internal.linearWorkTrackerOAuth.claimLinearOAuthSetupInternal, {
+        stateHash: "single-use",
+        now: Date.now(),
+      }),
+    ).resolves.toMatchObject({ setupId: ids.setupId, projectId: ids.projectId });
+    await expect(
+      t.mutation(internal.linearWorkTrackerOAuth.claimLinearOAuthSetupInternal, {
+        stateHash: "single-use",
+        now: Date.now(),
+      }),
+    ).rejects.toThrow("Invalid or expired Linear OAuth state");
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.setupId, {
+        consumedAt: undefined,
+        stateHash: "expired",
+        expiresAt: Date.now() - 1,
+      });
+    });
+    await expect(
+      t.mutation(internal.linearWorkTrackerOAuth.claimLinearOAuthSetupInternal, {
+        stateHash: "expired",
+        now: Date.now(),
+      }),
+    ).rejects.toThrow("Invalid or expired Linear OAuth state");
+  });
+
+  it("keeps exactly one OAuth setup and never replaces stored credentials", async () => {
+    const { ids, owner, t } = await seed();
+    const args = {
+      projectId: ids.projectId,
+      stateHash: "replacement-state",
+      redirectUri: "https://api.example.com/work-trackers/linear/callback",
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    };
+
+    await expect(
+      owner.mutation(internal.linearWorkTrackerOAuth.createLinearOAuthSetupInternal, args),
+    ).rejects.toThrow("Discard the existing Linear authorization before starting again");
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.setupId, {
+        data: {
+          provider: "linear",
+          stage: "pending",
+          redirectUri: args.redirectUri,
+        },
+      });
+    });
+    await owner.mutation(internal.linearWorkTrackerOAuth.createLinearOAuthSetupInternal, args);
+
+    const setups = await t.run(async (ctx) =>
+      ctx.db
+        .query("workTrackerOAuthSetups")
+        .withIndex("by_project_provider", (q) =>
+          q.eq("projectId", ids.projectId).eq("provider", "linear"),
+        )
+        .collect(),
+    );
+    expect(setups).toHaveLength(1);
+    expect(setups[0]).toMatchObject({ stateHash: "replacement-state", data: { stage: "pending" } });
+  });
+
+  it("does not expose or mutate another owner's connection", async () => {
+    const { ids, t } = await seed();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        name: "Outsider",
+        tokenIdentifier: "outsider-token",
+      });
+    });
+    const outsider = t.withIdentity({ tokenIdentifier: "outsider-token" });
+
+    await expect(
+      outsider.query(api.linearWorkTrackerSettings.getLinearSettings, {
+        projectId: ids.projectId,
+      }),
+    ).rejects.toThrow("Not authorized to access this project");
+    await expect(
+      outsider.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+        projectId: ids.projectId,
+        setupId: ids.setupId,
+        teamId: "team-2",
+      }),
+    ).rejects.toThrow("Not authorized to access this project");
+  });
+
+  it("keeps the active connection when destination selection is invalid", async () => {
+    const { ids, owner, t } = await seed();
+
+    await expect(
+      owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+        projectId: ids.projectId,
+        setupId: ids.setupId,
+        teamId: "missing",
+      }),
+    ).rejects.toThrow("Linear team is not available");
+
+    expect(await t.run(async (ctx) => await ctx.db.get(ids.connectionId))).toMatchObject({
+      destinationLabel: "Old team",
+    });
+  });
+
+  it("blocks replacement and disconnection while a Handoff is unresolved", async () => {
+    const { ids, owner, t } = await seed();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("workItemHandoffs", {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "linear",
+        attemptCount: 1,
+        reconciliationCount: 0,
+        recovery: { provider: "linear", issueId: crypto.randomUUID() },
+        lifecycle: { state: "unknown" },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+
+    await expect(
+      owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+        projectId: ids.projectId,
+        setupId: ids.setupId,
+        teamId: "team-2",
+      }),
+    ).rejects.toThrow("Work Tracker change is blocked");
+    await expect(
+      owner.mutation(internal.workTrackerConnections.beginLinearDisconnectInternal, {
+        projectId: ids.projectId,
+        leaseId: "disconnect",
+        now: Date.now(),
+      }),
+    ).rejects.toThrow("Work Tracker change is blocked");
+  });
+
+  it("blocks same-destination credential replacement while a Handoff is unresolved", async () => {
+    const { ids, owner, t } = await seed();
+    await t.run(async (ctx) => {
+      const setup = await ctx.db.get(ids.setupId);
+      if (setup?.data.stage !== "ready") throw new Error("Expected ready setup");
+      await ctx.db.patch(ids.setupId, {
+        data: {
+          ...setup!.data,
+          authorization: {
+            organization: { id: "org-1", name: "Old workspace", urlKey: "old" },
+            teams: [{ id: "team-1", key: "OLD", name: "Old team" }],
+          },
+        },
+      });
+      await ctx.db.insert("workItemHandoffs", {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "linear",
+        attemptCount: 1,
+        reconciliationCount: 0,
+        recovery: { provider: "linear", issueId: crypto.randomUUID() },
+        lifecycle: { state: "pending", leaseExpiresAt: Date.now() + 60_000 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+
+    await expect(
+      owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+        projectId: ids.projectId,
+        setupId: ids.setupId,
+        teamId: "team-1",
+      }),
+    ).rejects.toThrow("Work Tracker change is blocked");
+  });
+
+  it("atomically replaces a settled connection and consumes its setup", async () => {
+    const { ids, owner, t } = await seed();
+
+    await owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+      projectId: ids.projectId,
+      setupId: ids.setupId,
+      teamId: "team-2",
+    });
+
+    const connections = await t.run(async (ctx) =>
+      ctx.db
+        .query("workTrackerConnections")
+        .withIndex("by_project_provider", (q) =>
+          q.eq("projectId", ids.projectId).eq("provider", "linear"),
+        )
+        .collect(),
+    );
+    expect(connections).toHaveLength(1);
+    expect(connections[0]).toMatchObject({
+      destinationLabel: "New team",
+      data: {
+        encryptedCredentials,
+        organizationId: "org-2",
+        pendingRevocation: { encryptedCredentials: oldEncryptedCredentials },
+        teamId: "team-2",
+      },
+    });
+    expect(await t.run(async (ctx) => await ctx.db.get(ids.setupId))).toBeNull();
+  });
+
+  it("serializes setup discard against destination selection", async () => {
+    const first = await seed();
+    await expect(
+      first.owner.mutation(
+        internal.linearWorkTrackerOAuth.claimLinearOAuthSetupDiscardInternal,
+        { projectId: first.ids.projectId, setupId: first.ids.setupId },
+      ),
+    ).resolves.toMatchObject({ encryptedCredentials });
+    await expect(
+      first.owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+        projectId: first.ids.projectId,
+        setupId: first.ids.setupId,
+        teamId: "team-2",
+      }),
+    ).rejects.toThrow("Linear setup is no longer available");
+    expect(await first.t.run(async (ctx) => await ctx.db.get(first.ids.setupId))).toMatchObject({
+      data: { stage: "discarding" },
+    });
+
+    const second = await seed();
+    await second.owner.mutation(internal.workTrackerConnections.selectLinearTeamInternal, {
+      projectId: second.ids.projectId,
+      setupId: second.ids.setupId,
+      teamId: "team-2",
+    });
+    await expect(
+      second.owner.mutation(
+        internal.linearWorkTrackerOAuth.claimLinearOAuthSetupDiscardInternal,
+        { projectId: second.ids.projectId, setupId: second.ids.setupId },
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects stale credential writes and disconnect finalization", async () => {
+    const { ids, owner, t } = await seed();
+    await expect(
+      owner.mutation(internal.workTrackerConnections.claimLinearRefreshInternal, {
+        connectionId: ids.connectionId,
+        leaseId: "refresh-a",
+        now: Date.now(),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      owner.mutation(internal.workTrackerConnections.completeLinearRefreshInternal, {
+        connectionId: ids.connectionId,
+        encryptedCredentials,
+        leaseId: "refresh-b",
+      }),
+    ).resolves.toBe(false);
+    expect(await t.run(async (ctx) => await ctx.db.get(ids.connectionId))).toMatchObject({
+      data: { credentialLease: { id: "refresh-a" } },
+    });
+
+    await t.run(async (ctx) => {
+      const connection = await ctx.db.get(ids.connectionId);
+      await ctx.db.patch(ids.connectionId, {
+        data: { ...connection!.data, credentialLease: undefined },
+      });
+    });
+    const begun = await owner.mutation(
+      internal.workTrackerConnections.beginLinearDisconnectInternal,
+      { projectId: ids.projectId, leaseId: "disconnect-a", now: Date.now() },
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.connectionId, {
+        data: { ...begun!.data, credentialLease: { id: "disconnect-b", expiresAt: Date.now() } },
+      });
+    });
+    await expect(
+      owner.mutation(internal.workTrackerConnections.finalizeLinearDisconnectInternal, {
+        projectId: ids.projectId,
+        connectionId: ids.connectionId,
+        leaseId: "disconnect-a",
+      }),
+    ).resolves.toEqual({ disconnected: false });
+    expect(await t.run(async (ctx) => await ctx.db.get(ids.connectionId))).not.toBeNull();
+  });
+
+  it("serializes Handoff reservation against disconnect", async () => {
+    const disconnectFirst = await seed();
+    await disconnectFirst.owner.mutation(
+      internal.workTrackerConnections.beginLinearDisconnectInternal,
+      {
+        projectId: disconnectFirst.ids.projectId,
+        leaseId: "disconnect-first",
+        now: Date.now(),
+      },
+    );
+    await expect(
+      disconnectFirst.t.mutation(internal.workItemHandoffs.reserveInternal, {
+        projectId: disconnectFirst.ids.projectId,
+        requestId: disconnectFirst.ids.requestId,
+        provider: "linear",
+      }),
+    ).rejects.toThrow("Work Tracker connection is not available");
+
+    const handoffFirst = await seed();
+    await handoffFirst.t.mutation(internal.workItemHandoffs.reserveInternal, {
+      projectId: handoffFirst.ids.projectId,
+      requestId: handoffFirst.ids.requestId,
+      provider: "linear",
+    });
+    await expect(
+      handoffFirst.owner.mutation(
+        internal.workTrackerConnections.beginLinearDisconnectInternal,
+        {
+          projectId: handoffFirst.ids.projectId,
+          leaseId: "disconnect-second",
+          now: Date.now(),
+        },
+      ),
+    ).rejects.toThrow("Work Tracker change is blocked");
+  });
+
+  it("clears an expired refresh lease and restores Handoff reservation", async () => {
+    const ownerFinishes = await seed();
+    await ownerFinishes.t.run(async (ctx) => {
+      const connection = await ctx.db.get(ownerFinishes.ids.connectionId);
+      await ctx.db.patch(ownerFinishes.ids.connectionId, {
+        data: {
+          ...connection!.data,
+          credentialLease: { id: "expired-refresh", expiresAt: Date.now() - 1 },
+        },
+      });
+    });
+
+    await expect(
+      ownerFinishes.owner.mutation(internal.workTrackerConnections.completeLinearRefreshInternal, {
+        connectionId: ownerFinishes.ids.connectionId,
+        encryptedCredentials,
+        leaseId: "expired-refresh",
+      }),
+    ).resolves.toBe(true);
+
+    const reservationWins = await seed();
+    await reservationWins.t.run(async (ctx) => {
+      const connection = await ctx.db.get(reservationWins.ids.connectionId);
+      await ctx.db.patch(reservationWins.ids.connectionId, {
+        data: {
+          ...connection!.data,
+          credentialLease: { id: "expired-refresh", expiresAt: Date.now() - 1 },
+        },
+      });
+    });
+    await expect(
+      reservationWins.t.mutation(internal.workItemHandoffs.reserveInternal, {
+        projectId: reservationWins.ids.projectId,
+        requestId: reservationWins.ids.requestId,
+        provider: "linear",
+      }),
+    ).resolves.toMatchObject({ lifecycle: { state: "pending" } });
+    expect(
+      (
+        await reservationWins.t.run(async (ctx) =>
+          ctx.db.get(reservationWins.ids.connectionId),
+        )
+      )?.data.credentialLease,
+    ).toBeUndefined();
+    await expect(
+      reservationWins.owner.mutation(
+        internal.workTrackerConnections.completeLinearRefreshInternal,
+        {
+          connectionId: reservationWins.ids.connectionId,
+          encryptedCredentials,
+          leaseId: "expired-refresh",
+        },
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("blocks project deletion until credential-bearing Work Trackers are removed", async () => {
+    const { ids, owner, t } = await seed();
+
+    await expect(owner.mutation(api.projects.deleteProject, { id: ids.projectId })).rejects.toThrow(
+      "Disconnect Work Trackers before deleting this project",
+    );
+    await t.run(async (ctx) => await ctx.db.delete(ids.connectionId));
+    await expect(owner.mutation(api.projects.deleteProject, { id: ids.projectId })).rejects.toThrow(
+      "Disconnect Work Trackers before deleting this project",
+    );
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.setupId, {
+        data: {
+          provider: "linear",
+          stage: "pending",
+          redirectUri: "https://api.example.com/work-trackers/linear/callback",
+        },
+      });
+    });
+    await expect(owner.mutation(api.projects.deleteProject, { id: ids.projectId })).resolves.toBe(
+      null,
+    );
+    expect(await t.run(async (ctx) => await ctx.db.get(ids.setupId))).toBeNull();
+  });
+});

--- a/packages/convex-backend/convex/workTrackerConnections.ts
+++ b/packages/convex-backend/convex/workTrackerConnections.ts
@@ -1,0 +1,659 @@
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  mutation,
+} from "./_generated/server";
+import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
+import {
+  getLinearConfig,
+  LINEAR_CREDENTIAL_LEASE_MS,
+  LINEAR_REFRESH_EARLY_MS,
+  parseStoredCredentials,
+  serializeCredentials,
+} from "./lib/linearConnection";
+import {
+  discoverLinearWorkspace,
+  refreshLinearCredentials,
+  revokeLinearCredentials,
+} from "./lib/linearOAuth";
+import {
+  decryptWorkTrackerSecret,
+  encryptWorkTrackerSecret,
+} from "./lib/workTrackerSecrets";
+import { assertNoBlockingLinearHandoffs } from "./lib/workTrackerGuards";
+import { isWorkTrackerCredentialLeaseActive } from "./lib/workTrackerConnection";
+
+
+export const selectLinearTeamInternal = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    setupId: v.id("workTrackerOAuthSetups"),
+    teamId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    connectionId?: Id<"workTrackerConnections">;
+    organization: { id: string; name: string; urlKey: string };
+    pendingRevocation?: { ciphertext: string; iv: string };
+    team: { id: string; key: string; name: string };
+  }> => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const setup = await ctx.db.get(args.setupId);
+    const authorization = setup?.data.stage === "ready" ? setup.data.authorization : undefined;
+    const encryptedCredentials =
+      setup?.data.stage === "ready" ? setup.data.encryptedCredentials : undefined;
+    if (
+      !setup ||
+      setup.projectId !== args.projectId ||
+      setup.provider !== "linear" ||
+      setup.expiresAt <= Date.now() ||
+      !authorization ||
+      !encryptedCredentials
+    ) {
+      throw new Error("Linear setup is no longer available");
+    }
+    const team = authorization.teams.find((candidate) => candidate.id === args.teamId);
+    if (!team) {
+      throw new Error("Linear team is not available");
+    }
+
+    const existing = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+    const now = Date.now();
+    if (isWorkTrackerCredentialLeaseActive(existing?.data.credentialLease, now)) {
+      throw new Error("Linear credentials are busy; try again shortly");
+    }
+    if (existing?.data.pendingRevocation) {
+      throw new Error("The previous Linear authorization is still being revoked");
+    }
+    if (existing) {
+      await assertNoBlockingLinearHandoffs(ctx, args.projectId);
+    }
+
+    const data = {
+      provider: "linear" as const,
+      organizationId: authorization.organization.id,
+      organizationName: authorization.organization.name,
+      organizationUrlKey: authorization.organization.urlKey,
+      teamId: team.id,
+      teamKey: team.key,
+      teamName: team.name,
+      encryptedCredentials,
+      pendingRevocation: existing
+        ? { encryptedCredentials: existing.data.encryptedCredentials, retryAt: now }
+        : undefined,
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        health: "active",
+        destinationLabel: team.name,
+        data,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("workTrackerConnections", {
+        projectId: args.projectId,
+        provider: "linear",
+        health: "active",
+        destinationLabel: team.name,
+        data,
+        createdBy: user._id,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    await ctx.db.delete(setup._id);
+    return {
+      connectionId: existing?._id,
+      organization: authorization.organization,
+      pendingRevocation: existing?.data.encryptedCredentials,
+      team,
+    };
+  },
+});
+
+export const clearLinearPendingRevocationInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    ciphertext: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (
+      connection?.data.pendingRevocation?.encryptedCredentials.ciphertext !== args.ciphertext
+    ) {
+      return;
+    }
+    await ctx.db.patch(connection._id, {
+      data: { ...connection.data, pendingRevocation: undefined },
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const selectLinearTeam = action({
+  args: {
+    projectId: v.id("projects"),
+    setupId: v.id("workTrackerOAuthSetups"),
+    teamId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    organization: { id: string; name: string; urlKey: string };
+    team: { id: string; key: string; name: string };
+  }> => {
+    const result = await ctx.runMutation(
+      internal.workTrackerConnections.selectLinearTeamInternal,
+      args,
+    );
+    if (result.connectionId && result.pendingRevocation) {
+      try {
+        const config = getLinearConfig();
+        const credentials = parseStoredCredentials(
+          await decryptWorkTrackerSecret(result.pendingRevocation, config.encryptionKey),
+        );
+        await revokeLinearCredentials(credentials.refreshToken);
+        await ctx.runMutation(
+          internal.workTrackerConnections.clearLinearPendingRevocationInternal,
+          {
+            connectionId: result.connectionId,
+            ciphertext: result.pendingRevocation.ciphertext,
+          },
+        );
+      } catch (error) {
+        console.error("Replaced Linear credential revocation failed", {
+          connectionId: result.connectionId,
+          message: error instanceof Error ? error.message.slice(0, 200) : "Unknown error",
+        });
+      }
+    }
+    return { organization: result.organization, team: result.team };
+  },
+});
+
+export const getLinearConnectionForActionInternal = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    return await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+  },
+});
+
+export const claimLinearRefreshInternal = internalMutation({
+  args: { connectionId: v.id("workTrackerConnections"), leaseId: v.string(), now: v.number() },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      throw new Error("Linear connection not found");
+    }
+    await assertProjectOwner(ctx, connection.projectId, user._id);
+    if (isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, args.now)) {
+      return false;
+    }
+    await ctx.db.patch(connection._id, {
+      data: {
+        ...connection.data,
+        credentialLease: {
+          id: args.leaseId,
+          expiresAt: args.now + LINEAR_CREDENTIAL_LEASE_MS,
+        },
+      },
+      updatedAt: args.now,
+    });
+    return true;
+  },
+});
+
+export const completeLinearRefreshInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    encryptedCredentials: v.object({ ciphertext: v.string(), iv: v.string() }),
+    leaseId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      throw new Error("Linear connection not found");
+    }
+    await assertProjectOwner(ctx, connection.projectId, user._id);
+    if (connection.data.credentialLease?.id !== args.leaseId) {
+      return false;
+    }
+    await ctx.db.patch(connection._id, {
+      health: "active",
+      data: {
+        ...connection.data,
+        encryptedCredentials: args.encryptedCredentials,
+        credentialLease: undefined,
+      },
+      updatedAt: Date.now(),
+    });
+    return true;
+  },
+});
+
+export const failLinearRefreshInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    needsAttention: v.boolean(),
+    leaseId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      return;
+    }
+    await assertProjectOwner(ctx, connection.projectId, user._id);
+    if (connection.data.credentialLease?.id !== args.leaseId) {
+      return;
+    }
+    await ctx.db.patch(connection._id, {
+      health: args.needsAttention ? "needs_attention" : connection.health,
+      data: { ...connection.data, credentialLease: undefined },
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+async function getFreshLinearConnection(ctx: ActionCtx, projectId: Id<"projects">) {
+  const config = getLinearConfig();
+  let connection = await ctx.runQuery(
+    internal.workTrackerConnections.getLinearConnectionForActionInternal,
+    { projectId },
+  );
+  if (!connection) {
+    throw new Error("Linear connection not found");
+  }
+  let credentials = parseStoredCredentials(
+    await decryptWorkTrackerSecret(connection.data.encryptedCredentials, config.encryptionKey),
+  );
+  if (credentials.expiresAt > Date.now() + LINEAR_REFRESH_EARLY_MS) {
+    return { connection, credentials };
+  }
+
+  const leaseId = crypto.randomUUID();
+  const claimed = await ctx.runMutation(
+    internal.workTrackerConnections.claimLinearRefreshInternal,
+    { connectionId: connection._id, leaseId, now: Date.now() },
+  );
+  if (!claimed) {
+    connection = await ctx.runQuery(
+      internal.workTrackerConnections.getLinearConnectionForActionInternal,
+      { projectId },
+    );
+    if (!connection) {
+      throw new Error("Linear connection not found");
+    }
+    credentials = parseStoredCredentials(
+      await decryptWorkTrackerSecret(connection.data.encryptedCredentials, config.encryptionKey),
+    );
+    if (credentials.expiresAt <= Date.now() + LINEAR_REFRESH_EARLY_MS) {
+      throw new Error("Linear credentials are already refreshing");
+    }
+    return { connection, credentials };
+  }
+
+  let rotatedRefreshToken: string | undefined;
+  let stored = false;
+  try {
+    const refreshed = await refreshLinearCredentials({
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      refreshToken: credentials.refreshToken,
+    });
+    rotatedRefreshToken = refreshed.refreshToken;
+    const now = Date.now();
+    const encryptedCredentials = await encryptWorkTrackerSecret(
+      serializeCredentials(refreshed, now),
+      config.encryptionKey,
+    );
+    const saved = await ctx.runMutation(
+      internal.workTrackerConnections.completeLinearRefreshInternal,
+      {
+        connectionId: connection._id,
+        encryptedCredentials,
+        leaseId,
+      },
+    );
+    if (!saved) {
+      throw new Error("Linear refresh lease expired");
+    }
+    stored = true;
+    const currentConnection = await ctx.runQuery(
+      internal.workTrackerConnections.getLinearConnectionForActionInternal,
+      { projectId },
+    );
+    if (!currentConnection) {
+      throw new Error("Linear connection not found");
+    }
+    return {
+      connection: currentConnection,
+      credentials: { ...refreshed, expiresAt: now + refreshed.expiresIn * 1000 },
+    };
+  } catch (error) {
+    if (rotatedRefreshToken && !stored) {
+      try {
+        await revokeLinearCredentials(rotatedRefreshToken);
+      } catch {
+        // The connection is marked for attention below because rotation may have invalidated it.
+      }
+    }
+    const needsAttention =
+      Boolean(rotatedRefreshToken && !stored) ||
+      (error instanceof Error &&
+        error.message === "Linear authorization is invalid");
+    await ctx.runMutation(internal.workTrackerConnections.failLinearRefreshInternal, {
+      connectionId: connection._id,
+      needsAttention,
+      leaseId,
+    });
+    throw new Error("Unable to refresh Linear connection");
+  }
+}
+
+export const syncLinearDiscoveryInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    credentialCiphertext: v.string(),
+    organization: v.object({ id: v.string(), name: v.string(), urlKey: v.string() }),
+    selectedTeam: v.union(
+      v.null(),
+      v.object({ id: v.string(), key: v.string(), name: v.string() }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      throw new Error("Linear connection not found");
+    }
+    await assertProjectOwner(ctx, connection.projectId, user._id);
+    const now = Date.now();
+    if (
+      connection.data.encryptedCredentials.ciphertext !== args.credentialCiphertext ||
+      isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, now)
+    ) {
+      return false;
+    }
+    if (connection.data.organizationId !== args.organization.id) {
+      await ctx.db.patch(connection._id, {
+        health: "needs_attention",
+        data: { ...connection.data, credentialLease: undefined },
+        updatedAt: now,
+      });
+      return false;
+    }
+    await ctx.db.patch(connection._id, {
+      health: args.selectedTeam ? "active" : "needs_attention",
+      destinationLabel: args.selectedTeam?.name ?? connection.destinationLabel,
+      data: {
+        ...connection.data,
+        organizationId: args.organization.id,
+        organizationName: args.organization.name,
+        organizationUrlKey: args.organization.urlKey,
+        teamKey: args.selectedTeam?.key ?? connection.data.teamKey,
+        teamName: args.selectedTeam?.name ?? connection.data.teamName,
+        credentialLease: undefined,
+      },
+      updatedAt: now,
+    });
+    return true;
+  },
+});
+
+export const markLinearConnectionNeedsAttentionInternal = internalMutation({
+  args: { connectionId: v.id("workTrackerConnections"), credentialCiphertext: v.string() },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      return;
+    }
+    await assertProjectOwner(ctx, connection.projectId, user._id);
+    const now = Date.now();
+    if (
+      connection.data.encryptedCredentials.ciphertext !== args.credentialCiphertext ||
+      isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, now)
+    ) {
+      return;
+    }
+    await ctx.db.patch(connection._id, {
+      health: "needs_attention",
+      data: { ...connection.data, credentialLease: undefined },
+      updatedAt: now,
+    });
+  },
+});
+
+export const listLinearTeams = action({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<{ id: string; key: string; name: string }[]> => {
+    const { connection, credentials } = await getFreshLinearConnection(ctx, args.projectId);
+    try {
+      const discovery = await discoverLinearWorkspace(credentials.accessToken);
+      if (discovery.organization.id !== connection.data.organizationId) {
+        await ctx.runMutation(
+          internal.workTrackerConnections.markLinearConnectionNeedsAttentionInternal,
+          {
+            connectionId: connection._id,
+            credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+          },
+        );
+        throw new Error("Linear workspace no longer matches the connection");
+      }
+      const selectedTeam =
+        discovery.teams.find((team) => team.id === connection.data.teamId) ?? null;
+      await ctx.runMutation(internal.workTrackerConnections.syncLinearDiscoveryInternal, {
+        connectionId: connection._id,
+        credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+        organization: discovery.organization,
+        selectedTeam,
+      });
+      return discovery.teams;
+    } catch (error) {
+      if (error instanceof Error && error.message === "Linear authorization is invalid") {
+        await ctx.runMutation(
+          internal.workTrackerConnections.markLinearConnectionNeedsAttentionInternal,
+          {
+            connectionId: connection._id,
+            credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+          },
+        );
+      }
+      throw new Error("Unable to load Linear teams");
+    }
+  },
+});
+
+export const changeLinearTeamInternal = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    connectionId: v.id("workTrackerConnections"),
+    credentialCiphertext: v.string(),
+    organization: v.object({ id: v.string(), name: v.string(), urlKey: v.string() }),
+    team: v.object({ id: v.string(), key: v.string(), name: v.string() }),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection || connection.projectId !== args.projectId) {
+      throw new Error("Linear connection not found");
+    }
+    const now = Date.now();
+    if (
+      connection.data.encryptedCredentials.ciphertext !== args.credentialCiphertext ||
+      isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, now)
+    ) {
+      throw new Error("Linear connection changed; reload and try again");
+    }
+    if (connection.data.teamId !== args.team.id) {
+      await assertNoBlockingLinearHandoffs(ctx, args.projectId);
+    }
+    await ctx.db.patch(connection._id, {
+      health: "active",
+      destinationLabel: args.team.name,
+      data: {
+        ...connection.data,
+        organizationId: args.organization.id,
+        organizationName: args.organization.name,
+        organizationUrlKey: args.organization.urlKey,
+        teamId: args.team.id,
+        teamKey: args.team.key,
+        teamName: args.team.name,
+        credentialLease: undefined,
+      },
+      updatedAt: now,
+    });
+    return { team: args.team };
+  },
+});
+
+export const changeLinearTeam = action({
+  args: { projectId: v.id("projects"), teamId: v.string() },
+  handler: async (ctx, args): Promise<{ team: { id: string; key: string; name: string } }> => {
+    const { connection, credentials } = await getFreshLinearConnection(ctx, args.projectId);
+    const discovery = await discoverLinearWorkspace(credentials.accessToken);
+    if (discovery.organization.id !== connection.data.organizationId) {
+      await ctx.runMutation(
+        internal.workTrackerConnections.markLinearConnectionNeedsAttentionInternal,
+        {
+          connectionId: connection._id,
+          credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+        },
+      );
+      throw new Error("Linear workspace no longer matches the connection");
+    }
+    const team = discovery.teams.find((candidate) => candidate.id === args.teamId);
+    if (!team) {
+      throw new Error("Linear team is not available");
+    }
+    return await ctx.runMutation(internal.workTrackerConnections.changeLinearTeamInternal, {
+      projectId: args.projectId,
+      connectionId: connection._id,
+      credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+      organization: discovery.organization,
+      team,
+    });
+  },
+});
+
+export const beginLinearDisconnectInternal = internalMutation({
+  args: { projectId: v.id("projects"), leaseId: v.string(), now: v.number() },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    await assertNoBlockingLinearHandoffs(ctx, args.projectId);
+    const connection = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", "linear"),
+      )
+      .unique();
+    if (!connection) {
+      return null;
+    }
+    if (isWorkTrackerCredentialLeaseActive(connection.data.credentialLease, args.now)) {
+      throw new Error("Linear credentials are busy; try again shortly");
+    }
+    if (connection.data.pendingRevocation) {
+      throw new Error("The previous Linear authorization is still being revoked");
+    }
+    const data = {
+      ...connection.data,
+      credentialLease: {
+        id: args.leaseId,
+        expiresAt: args.now + LINEAR_CREDENTIAL_LEASE_MS,
+      },
+    };
+    await ctx.db.patch(connection._id, {
+      health: "needs_attention",
+      data,
+      updatedAt: args.now,
+    });
+    return { ...connection, data };
+  },
+});
+
+export const finalizeLinearDisconnectInternal = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    connectionId: v.id("workTrackerConnections"),
+    leaseId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    await assertProjectOwner(ctx, args.projectId, user._id);
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      return { disconnected: true };
+    }
+    if (
+      connection.projectId !== args.projectId ||
+      connection.data.credentialLease?.id !== args.leaseId
+    ) {
+      return { disconnected: false };
+    }
+    await ctx.db.delete(connection._id);
+    return { disconnected: true };
+  },
+});
+
+export const disconnectLinear = action({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<{ disconnected: true }> => {
+    const leaseId = crypto.randomUUID();
+    const connection = await ctx.runMutation(
+      internal.workTrackerConnections.beginLinearDisconnectInternal,
+      { ...args, leaseId, now: Date.now() },
+    );
+    if (connection) {
+      for (const encrypted of [connection.data.encryptedCredentials]) {
+        try {
+          const config = getLinearConfig();
+          const credentials = parseStoredCredentials(
+            await decryptWorkTrackerSecret(encrypted, config.encryptionKey),
+          );
+          await revokeLinearCredentials(credentials.refreshToken);
+        } catch (error) {
+          console.error("Linear credential revocation failed", {
+            connectionId: connection._id,
+            message: error instanceof Error ? error.message.slice(0, 200) : "Unknown error",
+          });
+        }
+      }
+      const result = await ctx.runMutation(
+        internal.workTrackerConnections.finalizeLinearDisconnectInternal,
+        { ...args, connectionId: connection._id, leaseId },
+      );
+      if (!result.disconnected) {
+        throw new Error("Linear connection changed during disconnect");
+      }
+    }
+    return { disconnected: true };
+  },
+});


### PR DESCRIPTION
## Summary
- add explicit Project Owner Linear OAuth setup with encrypted credentials and team selection
- add durable refresh, reconnection, revocation, cleanup, and disconnect fencing
- add the provider-neutral Work Trackers settings surface and Linear-specific card
- block project deletion and Handoff reservation across unsafe credential transitions

## Stack
- depends on #64

## Validation
- `bun lint`
- `bun check-types`
- `bun run test` (98 tests)
- `bun run build`
- `git diff --check`
- review-loop + thermo-nuclear review: approved, no blockers

Closes #56
Part of #52 and #60