### PR TITLE
feat: add source deep links

### DIFF
--- a/apps/wish-start/src/components/Request/DetailView/RequestDeatailView.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/RequestDeatailView.tsx
@@ -24,12 +24,20 @@ import { useRequestStatus } from "@/hooks/useRequestStatus";
 import { findCurrentStatus } from "@/lib/requestStatus/findCurrentStatus";
 
 interface Props {
-  children: ReactNode;
+  children?: ReactNode;
   request: Doc<"requests">;
   showUpvoteButton?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export default function RequestDetailView({ children, request, showUpvoteButton = true }: Props) {
+export default function RequestDetailView({
+  children,
+  request,
+  showUpvoteButton = true,
+  open,
+  onOpenChange,
+}: Props) {
   const [activeRequestId, setActiveRequestId] = useState(request._id);
   const requests = useRequests(request.project);
 
@@ -68,10 +76,12 @@ export default function RequestDetailView({ children, request, showUpvoteButton 
   const hasSuggestions = (suggestions?.length ?? 0) > 0;
   const isOriginalRequest = activeRequest._id === request._id;
   return (
-    <Dialog>
-      <DialogTrigger asChild className="cursor-pointer">
-        {children}
-      </DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {children ? (
+        <DialogTrigger asChild className="cursor-pointer">
+          {children}
+        </DialogTrigger>
+      ) : null}
       <DialogContent className="max-h-[85vh] overflow-hidden sm:max-w-106.25 md:max-w-5xl">
         <div
           className={

--- a/apps/wish-start/src/components/Request/DetailView/RequestDeepLink.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/RequestDeepLink.tsx
@@ -1,0 +1,57 @@
+import { useLocation, useRouter } from "@tanstack/react-router";
+import type { Id } from "@wish/convex-backend/data-model";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import useRequests from "@/hooks/useRequests";
+import { locationWithoutRequestItem } from "@/lib/requestDeepLink";
+
+import RequestDetailView from "./RequestDeatailView";
+
+interface Props {
+  projectId: Id<"projects">;
+  itemId: string;
+  kind?: "request" | "complaint";
+}
+
+export default function RequestDeepLink({ projectId, itemId, kind }: Props) {
+  const requests = useRequests(projectId, kind);
+  const location = useLocation();
+  const router = useRouter();
+  const lastRejectedItem = useRef<string | undefined>(undefined);
+  const request = requests.value?.find((candidate) => candidate._id === itemId);
+
+  useEffect(() => {
+    if (requests.isPending || requests.error || request) return;
+
+    if (lastRejectedItem.current !== itemId) {
+      toast.error(kind === "complaint" ? "Complaint not found" : "Request not found");
+      lastRejectedItem.current = itemId;
+    }
+
+    router.history.replace(locationWithoutRequestItem(location.pathname, location.searchStr));
+  }, [
+    itemId,
+    kind,
+    location.pathname,
+    location.searchStr,
+    request,
+    requests.error,
+    requests.isPending,
+    router,
+  ]);
+
+  if (!request) return null;
+
+  return (
+    <RequestDetailView
+      request={request}
+      showUpvoteButton={kind !== "complaint"}
+      open
+      onOpenChange={(open) => {
+        if (open) return;
+        router.history.replace(locationWithoutRequestItem(location.pathname, location.searchStr));
+      }}
+    />
+  );
+}

--- a/apps/wish-start/src/components/dashboard/DashboardBoard.tsx
+++ b/apps/wish-start/src/components/dashboard/DashboardBoard.tsx
@@ -5,14 +5,16 @@ import { api } from "@wish/convex-backend/api";
 import type { Id } from "@wish/convex-backend/data-model";
 import { useQuery } from "convex/react";
 
+import RequestDeepLink from "../Request/DetailView/RequestDeepLink";
 import RequestTable from "../Request/RequestTable";
 
 interface Props {
   projectId: Id<"projects">;
   boardType: BoardType;
   kind?: "request" | "complaint";
+  itemId?: string;
 }
-export default function DashboardBoard({ projectId, boardType, kind }: Props) {
+export default function DashboardBoard({ projectId, boardType, kind, itemId }: Props) {
   const project = useQuery(api.projects.getProjectById, { id: projectId });
 
   if (!project) return null;
@@ -20,6 +22,7 @@ export default function DashboardBoard({ projectId, boardType, kind }: Props) {
   return (
     // <div className="sidebar-offset-pl h-full">
     <div className="flex h-full w-full gap-2 overflow-x-scroll pt-px pr-6 sidebar-offset-pl ">
+      {itemId ? <RequestDeepLink projectId={projectId} kind={kind} itemId={itemId} /> : null}
       {boardType === "kanban" ? (
         <RequestKanban projectId={project._id} kind={kind} />
       ) : (

--- a/apps/wish-start/src/lib/requestDeepLink.test.ts
+++ b/apps/wish-start/src/lib/requestDeepLink.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { locationWithoutRequestItem, requestItemFromSearch } from "./requestDeepLink";
+
+describe("request deep links", () => {
+  it("accepts a non-empty request id", () => {
+    expect(requestItemFromSearch(" request-123 ")).toBe("request-123");
+  });
+
+  it("rejects missing and empty request ids", () => {
+    expect(requestItemFromSearch(undefined)).toBeUndefined();
+    expect(requestItemFromSearch(123)).toBeUndefined();
+    expect(requestItemFromSearch("   ")).toBeUndefined();
+  });
+
+  it("removes the item while preserving other search parameters", () => {
+    expect(
+      locationWithoutRequestItem(
+        "/dashboard/project/project-1/example/requests",
+        "?settings=work-trackers&item=request-1&linear=connected",
+      ),
+    ).toBe(
+      "/dashboard/project/project-1/example/requests?settings=work-trackers&linear=connected",
+    );
+  });
+
+  it("removes the search suffix when item is the only parameter", () => {
+    expect(
+      locationWithoutRequestItem(
+        "/dashboard/project/project-1/example/complaints",
+        "?item=complaint-1",
+      ),
+    ).toBe("/dashboard/project/project-1/example/complaints");
+  });
+});

--- a/apps/wish-start/src/lib/requestDeepLink.ts
+++ b/apps/wish-start/src/lib/requestDeepLink.ts
@@ -1,0 +1,14 @@
+export function requestItemFromSearch(value: unknown) {
+  if (typeof value !== "string") return;
+
+  const item = value.trim();
+  return item.length > 0 ? item : undefined;
+}
+
+export function locationWithoutRequestItem(pathname: string, searchString: string) {
+  const search = new URLSearchParams(searchString);
+  search.delete("item");
+
+  const suffix = search.toString();
+  return `${pathname}${suffix ? `?${suffix}` : ""}`;
+}

--- a/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.complaints.tsx
+++ b/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.complaints.tsx
@@ -5,13 +5,16 @@ import ButtonSwitcher from "@components/molecules/ButtonSwitcher";
 import { createFileRoute } from "@tanstack/react-router";
 
 import DashboardBoard from "@/components/dashboard/DashboardBoard";
+import { requestItemFromSearch } from "@/lib/requestDeepLink";
 
 export const Route = createFileRoute("/dashboard/project/$projectId/$slug/complaints")({
+  validateSearch: (search) => ({ item: requestItemFromSearch(search.item) }),
   component: ProjectComplaintsRoute,
 });
 
 function ProjectComplaintsRoute() {
   const { projectId, slug } = Route.useParams();
+  const { item } = Route.useSearch();
   const { type: boardType, switchTo: switchToBoardType } = useBoardType();
 
   return (
@@ -34,7 +37,12 @@ function ProjectComplaintsRoute() {
         }
       ></DashboardPage>
       {/*outside page scope for styling purpouses */}
-      <DashboardBoard projectId={projectId as never} boardType={boardType} kind="complaint" />
+      <DashboardBoard
+        projectId={projectId as never}
+        boardType={boardType}
+        kind="complaint"
+        itemId={item}
+      />
     </>
   );
 }

--- a/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.index.tsx
+++ b/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.index.tsx
@@ -5,6 +5,7 @@ export const Route = createFileRoute("/dashboard/project/$projectId/$slug/")({
     throw redirect({
       to: "/dashboard/project/$projectId/$slug/requests",
       params,
+      search: { item: undefined },
     });
   },
 });

--- a/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.requests.tsx
+++ b/apps/wish-start/src/routes/dashboard.project.$projectId.$slug.requests.tsx
@@ -6,13 +6,16 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import DashboardBoard from "@/components/dashboard/DashboardBoard";
 import { RequestsCreateEditButton } from "@/components/Request/RequestCreateEditDialog";
+import { requestItemFromSearch } from "@/lib/requestDeepLink";
 
 export const Route = createFileRoute("/dashboard/project/$projectId/$slug/requests")({
+  validateSearch: (search) => ({ item: requestItemFromSearch(search.item) }),
   component: ProjectRequestsRoute,
 });
 
 function ProjectRequestsRoute() {
   const { projectId, slug } = Route.useParams();
+  const { item } = Route.useSearch();
   const { type: boardType, switchTo: switchToBoardType } = useBoardType();
 
   return (
@@ -36,7 +39,7 @@ function ProjectRequestsRoute() {
         }
       ></DashboardPage>
       {/*outside page scope for styling purpouses */}
-      <DashboardBoard projectId={projectId as never} boardType={boardType} />
+      <DashboardBoard projectId={projectId as never} boardType={boardType} itemId={item} />
     </>
   );
 }


### PR DESCRIPTION
Stacked on #65. Part of #52 and #60.

## Summary
- open owner-only Request and Complaint details from explicit item query parameters
- keep project and source-kind isolation through the existing authenticated Convex query
- remove the item parameter on close or invalid IDs while preserving other search parameters
- keep existing row and card dialogs uncontrolled

## Validation
- bun lint
- bun check-types
- bun run test (102 tests)
- bun run build
- git diff --check
- review-loop: APPROVED
- thermo-nuclear review: APPROVED

## Runtime note
The managed browser session dropped during Clerk handoff, so browser smoke verification is deferred; the repository gates and both required independent reviews passed.