### PR TITLE
feat: add Linear handoff actions

### DIFF
--- a/apps/wish-start/src/components/Request/DetailView/RequestDeatailView.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/RequestDeatailView.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 import CommentsPanel from "@/components/Request/Comments/CommentsPanel";
+import WorkItemHandoffAction from "@/components/Request/DetailView/WorkItemHandoffAction";
 import RequestUpvoteButton from "@/components/Request/RequestUpvoteButton";
 import StatusForwardBadge from "@/components/Status/StatusForwardBadge";
 import { Badge } from "@/components/ui/badge";
@@ -102,6 +103,9 @@ export default function RequestDetailView({
                   />
                 ) : null}
                 {requestStatus.state.current && <StatusForwardBadge status={requestStatus} />}
+                <div className="ml-auto">
+                  <WorkItemHandoffAction request={activeRequest} />
+                </div>
               </div>
               <div>
                 <div className="mb-8 flex flex-wrap gap-3 text-sm text-foreground/50 *:flex *:items-center *:gap-2">

--- a/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useLocation, useRouter } from "@tanstack/react-router";
+import { api } from "@wish/convex-backend/api";
+import type { Doc } from "@wish/convex-backend/data-model";
+import { useAction, useQuery } from "convex/react";
+import { ExternalLink, RefreshCw, Send, Settings2, Wrench } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { getWorkItemHandoffAction } from "@/lib/workItemHandoffUi";
+import { getWorkTrackerError } from "@/lib/workTrackerErrors";
+
+function errorMessage(error: unknown, fallback: string) {
+  return getWorkTrackerError(error)?.message ?? fallback;
+}
+
+function showHandoffResult(handoff: Doc<"workItemHandoffs">) {
+  if (handoff.lifecycle.state === "succeeded") {
+    const issue = handoff.lifecycle.externalIdentity;
+    toast.success("Linear issue ready", {
+      description: (
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 font-medium text-orange-700 underline underline-offset-2 dark:text-orange-300"
+        >
+          {issue.identifier}
+          <ExternalLink className="size-3" />
+        </a>
+      ),
+    });
+    return;
+  }
+  if (handoff.lifecycle.state === "failed") {
+    toast.error(handoff.lifecycle.errorMessage);
+    return;
+  }
+  if (handoff.lifecycle.state === "unknown") {
+    toast.warning("Linear delivery is being checked", {
+      description:
+        "Wish will not send the issue twice while the outcome is uncertain.",
+    });
+    return;
+  }
+  toast.message("Creating Linear issue");
+}
+
+export default function WorkItemHandoffAction({
+  request,
+}: {
+  request: Doc<"requests">;
+}) {
+  const provider = "linear" as const;
+  const surface = useQuery(api.workItemHandoffs.getSurface, {
+    projectId: request.project,
+    requestId: request._id,
+    provider,
+  });
+  const sendHandoff = useAction(api.workItemHandoffs.send);
+  const checkHandoff = useAction(api.workItemHandoffs.check);
+  const location = useLocation();
+  const router = useRouter();
+  const [working, setWorking] = useState(false);
+
+  if (!surface) {
+    return (
+      <Button type="button" size="sm" variant="outline" disabled>
+        <Spinner /> Loading Linear
+      </Button>
+    );
+  }
+
+  const action = getWorkItemHandoffAction(surface);
+  const issue =
+    surface.handoff?.lifecycle.state === "succeeded"
+      ? surface.handoff.lifecycle.externalIdentity
+      : undefined;
+
+  function openSettings() {
+    const search = new URLSearchParams(location.searchStr);
+    search.set("settings", "work-trackers");
+    router.history.push(`${location.pathname}?${search.toString()}`);
+  }
+
+  async function send() {
+    setWorking(true);
+    try {
+      const result = await sendHandoff({
+        projectId: request.project,
+        requestId: request._id,
+        provider,
+      });
+      showHandoffResult(result);
+    } catch (error) {
+      toast.error(errorMessage(error, "Could not send this item to Linear"));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function check() {
+    setWorking(true);
+    try {
+      const result = await checkHandoff({
+        projectId: request.project,
+        requestId: request._id,
+        provider,
+      });
+      if (result) showHandoffResult(result);
+    } catch (error) {
+      toast.error(errorMessage(error, "Could not check the Linear issue"));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  if (action === "open" && issue) {
+    return (
+      <Button size="sm" variant="outline" asChild>
+        <a href={issue.url} target="_blank" rel="noreferrer">
+          {issue.identifier} <ExternalLink />
+        </a>
+      </Button>
+    );
+  }
+
+  if (action === "connect" || action === "fix") {
+    return (
+      <Button type="button" size="sm" variant="outline" onClick={openSettings}>
+        {action === "connect" ? <Settings2 /> : <Wrench />}
+        {action === "connect" ? "Connect Linear" : "Fix Linear"}
+      </Button>
+    );
+  }
+
+  if (action === "checking") {
+    const pending = surface.handoff?.lifecycle.state === "pending";
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={working || pending}
+        onClick={() => void check()}
+      >
+        {working || pending ? <Spinner /> : <RefreshCw />}
+        {working || pending ? "Checking Linear" : "Check Linear"}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      disabled={working}
+      onClick={() => void send()}
+    >
+      {working ? <Spinner /> : <Send />}
+      {working
+        ? "Sending"
+        : action === "retry"
+          ? "Retry Linear"
+          : "Send to Linear"}
+    </Button>
+  );
+}

--- a/apps/wish-start/src/components/Request/RequestCardActions.tsx
+++ b/apps/wish-start/src/components/Request/RequestCardActions.tsx
@@ -4,6 +4,7 @@ import type { Doc } from "@wish/convex-backend/data-model";
 import { useMutation } from "convex/react";
 import { Ellipsis } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import {
   Dialog,
@@ -14,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { getWorkTrackerError } from "@/lib/workTrackerErrors";
 
 import { Button } from "../ui/button";
 import {
@@ -24,6 +26,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { Spinner } from "../ui/spinner";
 
 import RequestCreateEditDialog from "./RequestCreateEditDialog";
 
@@ -39,11 +42,27 @@ export default function RequestCardActions({
 }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [isEdit, setIsEdit] = useState(false);
-  const deleteProject = useMutation(api.requests.deleteRequest);
+  const [deleting, setDeleting] = useState(false);
+  const deleteRequest = useMutation(api.requests.deleteRequest);
 
-  const handleSubmit = () => {
-    deleteProject({ id: request._id });
-    setIsOpen(false);
+  const handleSubmit = async () => {
+    setDeleting(true);
+    try {
+      await deleteRequest({ id: request._id });
+      setIsOpen(false);
+      toast.success(`${label} deleted`);
+    } catch (error) {
+      const workTrackerError = getWorkTrackerError(error);
+      if (workTrackerError) {
+        toast.error(`${label} cannot be deleted yet`, {
+          description: workTrackerError.message,
+        });
+      } else {
+        toast.error(`Could not delete ${label.toLowerCase()}`);
+      }
+    } finally {
+      setDeleting(false);
+    }
   };
 
   return (
@@ -101,12 +120,13 @@ export default function RequestCardActions({
             </DialogHeader>
             <DialogFooter>
               <DialogClose asChild>
-                <Button type="button" variant="outline">
+                <Button type="button" variant="outline" disabled={deleting}>
                   Cancel
                 </Button>
               </DialogClose>
-              <Button type="submit" variant="destructive">
-                Delete
+              <Button type="submit" variant="destructive" disabled={deleting}>
+                {deleting ? <Spinner /> : null}
+                {deleting ? "Deleting" : "Delete"}
               </Button>
             </DialogFooter>
           </form>

--- a/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
+++ b/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { getInitialLinearTeamId, parseLinearCallbackResult } from "@/lib/linearWorkTrackerUi";
+import { getWorkTrackerError } from "@/lib/workTrackerErrors";
 
 const callbackMessages = {
   authorized: {
@@ -74,6 +75,10 @@ const callbackMessages = {
 
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function workTrackerChangeError(error: unknown, fallback: string) {
+  return getWorkTrackerError(error)?.message ?? errorMessage(error, fallback);
 }
 
 export default function LinearWorkTrackerCard({
@@ -147,7 +152,7 @@ export default function LinearWorkTrackerCard({
         setAvailableTeams(null);
         toast.success(`Linear destination changed to ${result.team.name}`);
       } catch (error) {
-        toast.error(errorMessage(error, "Could not change the Linear team"));
+        toast.error(workTrackerChangeError(error, "Could not change the Linear team"));
       }
     });
   }
@@ -159,7 +164,7 @@ export default function LinearWorkTrackerCard({
         setAvailableTeams(null);
         toast.success("Linear disconnected");
       } catch (error) {
-        toast.error(errorMessage(error, "Could not disconnect Linear"));
+        toast.error(workTrackerChangeError(error, "Could not disconnect Linear"));
       }
     });
   }
@@ -262,7 +267,7 @@ export default function LinearWorkTrackerCard({
                     });
                     toast.success(`Linear connected to ${result.team.name}`);
                   } catch (error) {
-                    toast.error(errorMessage(error, "Could not save the Linear destination"));
+                    toast.error(workTrackerChangeError(error, "Could not save the Linear destination"));
                   }
                 });
               }}

--- a/apps/wish-start/src/lib/workItemHandoffUi.test.ts
+++ b/apps/wish-start/src/lib/workItemHandoffUi.test.ts
@@ -1,0 +1,75 @@
+import type { Doc, Id } from "@wish/convex-backend/data-model";
+import { describe, expect, it } from "vite-plus/test";
+
+import { getWorkItemHandoffAction } from "./workItemHandoffUi";
+
+const connection = { health: "active" as const, destinationLabel: "Engineering" };
+
+function handoff(lifecycle: Doc<"workItemHandoffs">["lifecycle"]): Doc<"workItemHandoffs"> {
+  return {
+    _id: "handoff-id" as Id<"workItemHandoffs">,
+    _creationTime: 1,
+    projectId: "project-id" as Id<"projects">,
+    requestId: "request-id" as Id<"requests">,
+    provider: "linear",
+    attemptCount: 1,
+    reconciliationCount: 0,
+    recovery: { provider: "linear", issueId: "issue-id" },
+    lifecycle,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe("Work Item Handoff UI", () => {
+  it("derives the explicit owner action from normalized facts", () => {
+    expect(getWorkItemHandoffAction({ connection: null, handoff: null })).toBe("connect");
+    expect(getWorkItemHandoffAction({ connection, handoff: null })).toBe("send");
+    expect(
+      getWorkItemHandoffAction({
+        connection: { ...connection, health: "needs_attention" },
+        handoff: null,
+      }),
+    ).toBe("fix");
+    expect(
+      getWorkItemHandoffAction({
+        connection,
+        handoff: handoff({ state: "pending", leaseExpiresAt: 1 }),
+      }),
+    ).toBe("checking");
+    expect(
+      getWorkItemHandoffAction({
+        connection,
+        handoff: handoff({
+          state: "unknown",
+          errorCode: "linear_outcome_unknown",
+          errorMessage: "Outcome unknown",
+        }),
+      }),
+    ).toBe("checking");
+    expect(
+      getWorkItemHandoffAction({
+        connection,
+        handoff: handoff({ state: "failed", errorCode: "linear_rejected", errorMessage: "Failed" }),
+      }),
+    ).toBe("retry");
+  });
+
+  it("keeps an existing external link available without a healthy connection", () => {
+    expect(
+      getWorkItemHandoffAction({
+        connection: null,
+        handoff: handoff({
+          state: "succeeded",
+          succeededAt: 1,
+          externalIdentity: {
+            provider: "linear",
+            id: "issue-id",
+            identifier: "ENG-42",
+            url: "https://linear.app/acme/issue/ENG-42",
+          },
+        }),
+      }),
+    ).toBe("open");
+  });
+});

--- a/apps/wish-start/src/lib/workItemHandoffUi.ts
+++ b/apps/wish-start/src/lib/workItemHandoffUi.ts
@@ -1,0 +1,18 @@
+import { api } from "@wish/convex-backend/api";
+import type { FunctionReturnType } from "convex/server";
+
+export function getWorkItemHandoffAction(
+  surface: FunctionReturnType<typeof api.workItemHandoffs.getSurface>,
+) {
+  if (surface.handoff?.lifecycle.state === "succeeded") return "open" as const;
+  if (!surface.connection) return "connect" as const;
+  if (surface.connection.health !== "active") return "fix" as const;
+  if (
+    surface.handoff?.lifecycle.state === "pending" ||
+    surface.handoff?.lifecycle.state === "unknown"
+  ) {
+    return "checking" as const;
+  }
+  if (surface.handoff?.lifecycle.state === "failed") return "retry" as const;
+  return "send" as const;
+}

--- a/apps/wish-start/src/lib/workTrackerErrors.test.ts
+++ b/apps/wish-start/src/lib/workTrackerErrors.test.ts
@@ -1,0 +1,28 @@
+import {
+  handoffCreationDisabledError,
+  unresolvedWorkItemHandoffError,
+  workTrackerConnectionNeedsAttentionError,
+} from "@wish/convex-backend/work-tracker-errors";
+import { describe, expect, it } from "vite-plus/test";
+
+import { getWorkTrackerError } from "./workTrackerErrors";
+
+describe("Work Tracker errors", () => {
+  it("maps the unresolved Handoff code without relying on an Error message", () => {
+    expect(
+      getWorkTrackerError({
+        data: { code: unresolvedWorkItemHandoffError.code },
+      }),
+    ).toEqual(unresolvedWorkItemHandoffError);
+    expect(
+      getWorkTrackerError({ data: { code: handoffCreationDisabledError.code } }),
+    ).toEqual(handoffCreationDisabledError);
+    expect(
+      getWorkTrackerError({ data: { code: workTrackerConnectionNeedsAttentionError.code } }),
+    ).toEqual(workTrackerConnectionNeedsAttentionError);
+    expect(
+      getWorkTrackerError(new Error("Work Item Handoff is unresolved")),
+    ).toBeNull();
+    expect(getWorkTrackerError({ data: { code: "UNKNOWN" } })).toBeNull();
+  });
+});

--- a/apps/wish-start/src/lib/workTrackerErrors.ts
+++ b/apps/wish-start/src/lib/workTrackerErrors.ts
@@ -1,0 +1,23 @@
+import {
+  handoffCreationDisabledError,
+  unresolvedWorkItemHandoffError,
+  workTrackerConnectionNeedsAttentionError,
+} from "@wish/convex-backend/work-tracker-errors";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function getWorkTrackerError(error: unknown) {
+  if (!isRecord(error) || !isRecord(error.data)) return null;
+  if (error.data.code === unresolvedWorkItemHandoffError.code) {
+    return unresolvedWorkItemHandoffError;
+  }
+  if (error.data.code === handoffCreationDisabledError.code) {
+    return handoffCreationDisabledError;
+  }
+  if (error.data.code === workTrackerConnectionNeedsAttentionError.code) {
+    return workTrackerConnectionNeedsAttentionError;
+  }
+  return null;
+}

--- a/packages/convex-backend/convex/lib/linearHandoffDelivery.ts
+++ b/packages/convex-backend/convex/lib/linearHandoffDelivery.ts
@@ -1,3 +1,5 @@
+import { ConvexError } from "convex/values";
+
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
@@ -6,6 +8,10 @@ import { getFreshLinearConnection } from "../workTrackerConnections";
 import { getLinearConfig, isLinearHandoffCreationEnabled } from "./linearConnection";
 import { buildLinearIssueDescription, buildWishSourceUrl, createLinearIssue } from "./linearIssue";
 import { getRequestKind } from "./requestKind";
+import {
+  handoffCreationDisabledError,
+  workTrackerConnectionNeedsAttentionError,
+} from "./workTrackerErrors";
 
 export async function sendLinearHandoff(
   ctx: ActionCtx,
@@ -30,7 +36,7 @@ export async function sendLinearHandoff(
   }
   if (handoff && handoff.lifecycle.state !== "failed") return handoff;
   if (!isLinearHandoffCreationEnabled()) {
-    throw new Error("Linear Handoff creation is disabled");
+    throw new ConvexError(handoffCreationDisabledError);
   }
 
   const config = getLinearConfig();
@@ -39,7 +45,7 @@ export async function sendLinearHandoff(
     { projectId: args.projectId },
   );
   if (!currentConnection || currentConnection.health !== "active") {
-    throw new Error("Linear connection needs attention");
+    throw new ConvexError(workTrackerConnectionNeedsAttentionError);
   }
 
   const reservation: {

--- a/packages/convex-backend/convex/lib/workTrackerErrors.ts
+++ b/packages/convex-backend/convex/lib/workTrackerErrors.ts
@@ -1,0 +1,14 @@
+export const unresolvedWorkItemHandoffError = {
+  code: "WORK_ITEM_HANDOFF_UNRESOLVED",
+  message: "Wait for the unresolved Work Tracker delivery check to finish.",
+} as const;
+
+export const handoffCreationDisabledError = {
+  code: "WORK_ITEM_HANDOFF_CREATION_DISABLED",
+  message: "Linear delivery is temporarily disabled",
+} as const;
+
+export const workTrackerConnectionNeedsAttentionError = {
+  code: "WORK_TRACKER_CONNECTION_NEEDS_ATTENTION",
+  message: "Fix the Linear connection before sending",
+} as const;

--- a/packages/convex-backend/convex/lib/workTrackerGuards.ts
+++ b/packages/convex-backend/convex/lib/workTrackerGuards.ts
@@ -1,5 +1,9 @@
+import { ConvexError } from "convex/values";
+
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+
+import { unresolvedWorkItemHandoffError } from "./workTrackerErrors";
 
 export async function assertNoBlockingLinearHandoffs(
   ctx: MutationCtx,
@@ -15,7 +19,7 @@ export async function assertNoBlockingLinearHandoffs(
       )
       .first();
     if (handoff) {
-      throw new Error("Work Tracker change is blocked while a Handoff is unresolved");
+      throw new ConvexError(unresolvedWorkItemHandoffError);
     }
   }
 }

--- a/packages/convex-backend/convex/requests.ts
+++ b/packages/convex-backend/convex/requests.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 
 import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
@@ -8,6 +8,7 @@ import { normalizeRequestInput, requestInputErrorMessage } from "./lib/requestIn
 import { getRequestKind } from "./lib/requestKind";
 import { assertStatusBelongsToProject } from "./lib/requestStatusWorkflow";
 import { isHandoffBlocking } from "./lib/workItemHandoff";
+import { unresolvedWorkItemHandoffError } from "./lib/workTrackerErrors";
 import { emitNotificationEvent } from "./notificationEvents";
 
 const requestKindValidator = v.union(v.literal("request"), v.literal("complaint"));
@@ -32,7 +33,7 @@ async function deleteRequestCascade(ctx: MutationCtx, id: Id<"requests">) {
     .withIndex("by_request", (q) => q.eq("requestId", id))
     .collect();
   if (handoffs.some((handoff) => isHandoffBlocking(handoff.lifecycle.state))) {
-    throw new Error("Request cannot be deleted while a Work Item Handoff is unresolved");
+    throw new ConvexError(unresolvedWorkItemHandoffError);
   }
 
   await Promise.all(upvotes.map((upvote) => ctx.db.delete(upvote._id)));
@@ -220,6 +221,7 @@ export const deleteRequest = mutation({
       await assertProjectOwner(ctx, request.project, user._id);
       await deleteRequestCascade(ctx, args.id);
     } catch (error) {
+      if (error instanceof ConvexError) throw error;
       console.error(error);
       throw new Error("Failed to delete request");
     }
@@ -240,6 +242,7 @@ export const deleteRequestByApiKeyInternal = internalMutation({
 
       await deleteRequestCascade(ctx, args.id);
     } catch (error) {
+      if (error instanceof ConvexError) throw error;
       console.error(error);
       throw new Error("Failed to delete request");
     }

--- a/packages/convex-backend/convex/workItemHandoffs.test.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.test.ts
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { api, internal } from "./_generated/api";
 import { serializeCredentials } from "./lib/linearConnection";
+import {
+  handoffCreationDisabledError,
+  unresolvedWorkItemHandoffError,
+  workTrackerConnectionNeedsAttentionError,
+} from "./lib/workTrackerErrors";
 import { encryptWorkTrackerSecret } from "./lib/workTrackerSecrets";
 import schema from "./schema";
 
@@ -117,6 +122,21 @@ async function configureLinearDelivery(
 }
 
 describe("Work Item Handoff delivery lifecycle", () => {
+  it("returns provider-neutral connection and Handoff facts", async () => {
+    const { ids, owner } = await seed();
+
+    await expect(
+      owner.query(api.workItemHandoffs.getSurface, {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "linear",
+      }),
+    ).resolves.toEqual({
+      connection: { health: "active", destinationLabel: "Engineering" },
+      handoff: null,
+    });
+  });
+
   it("sends once through the provider-neutral action and persists the Linear link", async () => {
     const { ids, owner, t } = await seed();
     await configureLinearDelivery(t, ids);
@@ -179,10 +199,22 @@ describe("Work Item Handoff delivery lifecycle", () => {
         requestId: ids.requestId,
         provider: "linear",
       }),
-    ).rejects.toThrow("Linear Handoff creation is disabled");
+    ).rejects.toMatchObject({ data: handoffCreationDisabledError });
     expect(await t.run(async (ctx) => await ctx.db.query("workItemHandoffs").collect())).toEqual(
       [],
     );
+
+    await configureLinearDelivery(t, ids);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.connectionId, { health: "needs_attention" });
+    });
+    await expect(
+      owner.action(api.workItemHandoffs.send, {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "linear",
+      }),
+    ).rejects.toMatchObject({ data: workTrackerConnectionNeedsAttentionError });
   });
 
   it("never repeats creation after an uncertain provider outcome", async () => {
@@ -549,9 +581,15 @@ describe("Work Item Handoff delivery lifecycle", () => {
     );
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
-    await expect(owner.mutation(api.requests.deleteRequest, { id: ids.requestId })).rejects.toThrow(
-      "Failed to delete request",
-    );
+    await expect(owner.mutation(api.requests.deleteRequest, { id: ids.requestId })).rejects.toMatchObject({
+      data: unresolvedWorkItemHandoffError,
+    });
+    await expect(
+      owner.mutation(internal.requests.deleteRequestByApiKeyInternal, {
+        id: ids.requestId,
+        projectId: ids.projectId,
+      }),
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
     await owner.mutation(internal.workItemHandoffs.completeFailedInternal, {
       handoffId: reservation.handoff._id,
       attemptCount: 1,

--- a/packages/convex-backend/convex/workItemHandoffs.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.ts
@@ -70,6 +70,29 @@ export const get = query({
   handler: async (ctx, args) => await getOwnedHandoff(ctx, args),
 });
 
+export const getSurface = query({
+  args: {
+    projectId: v.id("projects"),
+    requestId: v.id("requests"),
+    provider: workTrackerProviderValidator,
+  },
+  handler: async (ctx, args) => {
+    const handoff = await getOwnedHandoff(ctx, args);
+    const connection = await ctx.db
+      .query("workTrackerConnections")
+      .withIndex("by_project_provider", (q) =>
+        q.eq("projectId", args.projectId).eq("provider", args.provider),
+      )
+      .unique();
+    return {
+      connection: connection
+        ? { health: connection.health, destinationLabel: connection.destinationLabel }
+        : null,
+      handoff,
+    };
+  },
+});
+
 export const getOwnedInternal = internalQuery({
   args: {
     projectId: v.id("projects"),

--- a/packages/convex-backend/convex/workTrackerConnections.test.ts
+++ b/packages/convex-backend/convex/workTrackerConnections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { api, internal } from "./_generated/api";
 import { parseStoredCredentials } from "./lib/linearConnection";
+import { unresolvedWorkItemHandoffError } from "./lib/workTrackerErrors";
 import schema from "./schema";
 
 const modules = {
@@ -244,14 +245,14 @@ describe("Work Tracker connections", () => {
         setupId: ids.setupId,
         teamId: "team-2",
       }),
-    ).rejects.toThrow("Work Tracker change is blocked");
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
     await expect(
       owner.mutation(internal.workTrackerConnections.beginLinearDisconnectInternal, {
         projectId: ids.projectId,
         leaseId: "disconnect",
         now: Date.now(),
       }),
-    ).rejects.toThrow("Work Tracker change is blocked");
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
   });
 
   it("blocks same-destination credential replacement while a Handoff is pending", async () => {
@@ -287,7 +288,7 @@ describe("Work Tracker connections", () => {
         setupId: ids.setupId,
         teamId: "team-1",
       }),
-    ).rejects.toThrow("Work Tracker change is blocked");
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
   });
 
   it("allows same-destination credential repair for an unknown Handoff", async () => {
@@ -508,7 +509,7 @@ describe("Work Tracker connections", () => {
         leaseId: "disconnect-second",
         now: Date.now(),
       }),
-    ).rejects.toThrow("Work Tracker change is blocked");
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
   });
 
   it("clears an expired refresh lease and restores Handoff reservation", async () => {

--- a/packages/convex-backend/package.json
+++ b/packages/convex-backend/package.json
@@ -14,6 +14,10 @@
     "./notification-event-types": {
       "types": "./convex/lib/notificationEventTypes.ts",
       "default": "./convex/lib/notificationEventTypes.ts"
+    },
+    "./work-tracker-errors": {
+      "types": "./convex/lib/workTrackerErrors.ts",
+      "default": "./convex/lib/workTrackerErrors.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- add the explicit Request and Complaint detail action for connecting, sending, checking, retrying, and opening Linear issues
- show the created or recovered Linear issue link in Sonner success feedback
- expose provider-neutral handoff surface facts and structured Work Tracker errors
- block destructive source and connection changes with explicit reconciliation guidance

## Validation
- bun check-types
- bun lint
- bun run test (131 tests)
- bun run build
- review-loop: approved
- thermo-nuclear code-quality review: approved

## UI smoke
The public app rendered locally. Authenticated detail-flow automation was blocked when the local agent-device browser backend wedged while opening Clerk; no application runtime or build failure was observed.

Stacked on #67. Relates to #60.