### PR TITLE
feat: add GitHub issue delivery

### DIFF
--- a/docs/work-tracker-deployment.md
+++ b/docs/work-tracker-deployment.md
@@ -47,6 +47,10 @@ GitHub stays disabled until all six GitHub App configuration variables exist:
 The encryption key protects temporary GitHub credentials only while authorization cleanup must be
 retried.
 
+GitHub issue creation has a separate emergency brake:
+
+- `GITHUB_HANDOFF_CREATION_ENABLED`
+
 Create a public GitHub App with these settings:
 
 - Request user authorization during installation: enabled
@@ -78,4 +82,6 @@ stored only as one encrypted cleanup record until GitHub accepts revocation. If 
 fails, cleanup submits both tokens to GitHub's credential revocation endpoint without depending on
 the GitHub App client credentials. Runtime repository discovery uses short-lived installation tokens.
 Disconnecting GitHub in Wish removes only the local connection; it does not uninstall the GitHub
-App.
+App. Set `GITHUB_HANDOFF_CREATION_ENABLED=true` only after issue creation is ready for Project
+Owners. Set it to `false` to stop new and failed-retry creations without disabling connection
+management, existing issue links, or reconciliation of uncertain outcomes.

--- a/packages/convex-backend/convex/_generated/api.d.ts
+++ b/packages/convex-backend/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as apiKeys from "../apiKeys.js";
 import type * as changelogEntries from "../changelogEntries.js";
 import type * as crons from "../crons.js";
+import type * as githubWorkItemHandoffs from "../githubWorkItemHandoffs.js";
 import type * as githubWorkTrackerCleanup from "../githubWorkTrackerCleanup.js";
 import type * as githubWorkTrackerConnections from "../githubWorkTrackerConnections.js";
 import type * as githubWorkTrackerOAuth from "../githubWorkTrackerOAuth.js";
@@ -22,6 +23,8 @@ import type * as lib_authorization from "../lib/authorization.js";
 import type * as lib_changelogIntake from "../lib/changelogIntake.js";
 import type * as lib_githubApp from "../lib/githubApp.js";
 import type * as lib_githubConnection from "../lib/githubConnection.js";
+import type * as lib_githubHandoffDelivery from "../lib/githubHandoffDelivery.js";
+import type * as lib_githubIssue from "../lib/githubIssue.js";
 import type * as lib_githubWebhook from "../lib/githubWebhook.js";
 import type * as lib_linearConnection from "../lib/linearConnection.js";
 import type * as lib_linearHandoffDelivery from "../lib/linearHandoffDelivery.js";
@@ -46,6 +49,7 @@ import type * as lib_requestStatusWorkflow from "../lib/requestStatusWorkflow.js
 import type * as lib_requesterIdentity from "../lib/requesterIdentity.js";
 import type * as lib_suggestionPortalReadModel from "../lib/suggestionPortalReadModel.js";
 import type * as lib_workItemHandoff from "../lib/workItemHandoff.js";
+import type * as lib_workItemHandoffPayload from "../lib/workItemHandoffPayload.js";
 import type * as lib_workTrackerConfig from "../lib/workTrackerConfig.js";
 import type * as lib_workTrackerConnection from "../lib/workTrackerConnection.js";
 import type * as lib_workTrackerErrors from "../lib/workTrackerErrors.js";
@@ -85,6 +89,7 @@ declare const fullApi: ApiFromModules<{
   apiKeys: typeof apiKeys;
   changelogEntries: typeof changelogEntries;
   crons: typeof crons;
+  githubWorkItemHandoffs: typeof githubWorkItemHandoffs;
   githubWorkTrackerCleanup: typeof githubWorkTrackerCleanup;
   githubWorkTrackerConnections: typeof githubWorkTrackerConnections;
   githubWorkTrackerOAuth: typeof githubWorkTrackerOAuth;
@@ -96,6 +101,8 @@ declare const fullApi: ApiFromModules<{
   "lib/changelogIntake": typeof lib_changelogIntake;
   "lib/githubApp": typeof lib_githubApp;
   "lib/githubConnection": typeof lib_githubConnection;
+  "lib/githubHandoffDelivery": typeof lib_githubHandoffDelivery;
+  "lib/githubIssue": typeof lib_githubIssue;
   "lib/githubWebhook": typeof lib_githubWebhook;
   "lib/linearConnection": typeof lib_linearConnection;
   "lib/linearHandoffDelivery": typeof lib_linearHandoffDelivery;
@@ -120,6 +127,7 @@ declare const fullApi: ApiFromModules<{
   "lib/requesterIdentity": typeof lib_requesterIdentity;
   "lib/suggestionPortalReadModel": typeof lib_suggestionPortalReadModel;
   "lib/workItemHandoff": typeof lib_workItemHandoff;
+  "lib/workItemHandoffPayload": typeof lib_workItemHandoffPayload;
   "lib/workTrackerConfig": typeof lib_workTrackerConfig;
   "lib/workTrackerConnection": typeof lib_workTrackerConnection;
   "lib/workTrackerErrors": typeof lib_workTrackerErrors;

--- a/packages/convex-backend/convex/githubWorkItemHandoffs.test.ts
+++ b/packages/convex-backend/convex/githubWorkItemHandoffs.test.ts
@@ -1,0 +1,294 @@
+import { convexTest } from "convex-test";
+import { exportPKCS8, generateKeyPair } from "jose";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = {
+  "./_generated/server.ts": () => import("./_generated/server"),
+  "./githubWorkItemHandoffs.ts": () => import("./githubWorkItemHandoffs"),
+  "./workItemHandoffs.ts": () => import("./workItemHandoffs"),
+};
+
+let privateKey = "";
+
+beforeAll(async () => {
+  const keyPair = await generateKeyPair("RS256", { extractable: true });
+  privateKey = await exportPKCS8(keyPair.privateKey);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+async function seed() {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      name: "Owner",
+      tokenIdentifier: "owner-token",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      title: "Project",
+      projectSlug: "project",
+      user: userId,
+    });
+    const statusId = await ctx.db.insert("requestStatuses", {
+      name: "open",
+      displayName: "Open",
+      project: projectId,
+      type: "custom",
+    });
+    const requestId = await ctx.db.insert("requests", {
+      text: "Export reports",
+      description: "Let customers export reports",
+      clientId: "client",
+      status: statusId,
+      project: projectId,
+    });
+    const connectionId = await ctx.db.insert("workTrackerConnections", {
+      projectId,
+      provider: "github",
+      health: "active",
+      destinationLabel: "wishco/product",
+      data: {
+        provider: "github",
+        installationId: "501",
+        accountLogin: "wishco",
+        repository: {
+          id: "101",
+          nodeId: "R_101",
+          owner: "wishco",
+          name: "product",
+          fullName: "wishco/product",
+          url: "https://github.com/wishco/product",
+        },
+      },
+      createdBy: userId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    return { connectionId, projectId, requestId };
+  });
+  vi.stubEnv("GITHUB_APP_CLIENT_ID", "Iv1.client");
+  vi.stubEnv("GITHUB_APP_PRIVATE_KEY", privateKey);
+  vi.stubEnv("GITHUB_HANDOFF_CREATION_ENABLED", "true");
+  vi.stubEnv("WISH_APP_BASE_URL", "https://wish.example");
+  return { ids, owner: t.withIdentity({ tokenIdentifier: "owner-token" }), t };
+}
+
+function issueResponse() {
+  return Response.json(
+    {
+      id: 42,
+      node_id: "I_42",
+      number: 7,
+      html_url: "https://github.com/wishco/product/issues/7",
+    },
+    { status: 201 },
+  );
+}
+
+describe("GitHub Work Item Handoff delivery", () => {
+  it("creates once and persists the GitHub issue link", async () => {
+    const { ids, owner } = await seed();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(issueResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const args = {
+      projectId: ids.projectId,
+      requestId: ids.requestId,
+      provider: "github" as const,
+    };
+
+    const first = await owner.action(api.workItemHandoffs.send, args);
+    const second = await owner.action(api.workItemHandoffs.send, args);
+
+    expect(first.lifecycle).toMatchObject({
+      state: "succeeded",
+      externalIdentity: {
+        provider: "github",
+        identifier: "wishco/product#7",
+        url: "https://github.com/wishco/product/issues/7",
+      },
+    });
+    expect(second._id).toBe(first._id);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = String(fetchMock.mock.calls[1]?.[1]?.body);
+    expect(body).toContain("[View original in Wish](https://wish.example/dashboard/project/");
+    expect(body).not.toContain("client");
+  });
+
+  it("never repeats an uncertain creation and reconciles by the Wish link", async () => {
+    const { ids, owner } = await seed();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const args = {
+      projectId: ids.projectId,
+      requestId: ids.requestId,
+      provider: "github" as const,
+    };
+
+    const first = await owner.action(api.workItemHandoffs.send, args);
+    const second = await owner.action(api.workItemHandoffs.send, args);
+    expect(first.lifecycle.state).toBe("unknown");
+    expect(second.lifecycle.state).toBe("unknown");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    if (first.recovery.provider !== "github") throw new Error("Expected GitHub recovery data");
+
+    fetchMock
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            id: 42,
+            node_id: "I_42",
+            number: 7,
+            html_url: "https://github.com/wishco/product/issues/7",
+            body: `[View original in Wish](${first.recovery.sourceUrl})`,
+            created_at: new Date(first.recovery.startedAt + 1).toISOString(),
+          },
+        ]),
+      );
+
+    await expect(owner.action(api.workItemHandoffs.check, args)).resolves.toMatchObject({
+      lifecycle: { state: "succeeded" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("schedules the next reconciliation after a transient token failure", async () => {
+    const { ids, owner } = await seed();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const args = {
+      projectId: ids.projectId,
+      requestId: ids.requestId,
+      provider: "github" as const,
+    };
+    const handoff = await owner.action(api.workItemHandoffs.send, args);
+    expect(handoff.lifecycle.state).toBe("unknown");
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expect(owner.action(api.workItemHandoffs.check, args)).resolves.toMatchObject({
+      reconciliationCount: 1,
+      lifecycle: { state: "unknown" },
+    });
+  });
+
+  it("reconciles against current repository metadata after a rename", async () => {
+    const { ids, owner, t } = await seed();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const args = {
+      projectId: ids.projectId,
+      requestId: ids.requestId,
+      provider: "github" as const,
+    };
+    const handoff = await owner.action(api.workItemHandoffs.send, args);
+    if (handoff.recovery.provider !== "github") {
+      throw new Error("Expected GitHub recovery data");
+    }
+    await t.run(async (ctx) => {
+      const connection = await ctx.db.get(ids.connectionId);
+      if (!connection || connection.data.provider !== "github") {
+        throw new Error("Expected GitHub connection");
+      }
+      await ctx.db.patch(connection._id, {
+        destinationLabel: "wishhq/renamed",
+        data: {
+          ...connection.data,
+          repository: {
+            ...connection.data.repository,
+            owner: "wishhq",
+            name: "renamed",
+            fullName: "wishhq/renamed",
+            url: "https://github.com/wishhq/renamed",
+          },
+        },
+        updatedAt: connection.updatedAt + 1,
+      });
+    });
+    fetchMock
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            id: 42,
+            node_id: "I_42",
+            number: 7,
+            html_url: "https://github.com/wishhq/renamed/issues/7",
+            body: `[View original in Wish](${handoff.recovery.sourceUrl})`,
+            created_at: new Date(handoff.recovery.startedAt + 1).toISOString(),
+          },
+        ]),
+      );
+
+    await expect(owner.action(api.workItemHandoffs.check, args)).resolves.toMatchObject({
+      lifecycle: {
+        state: "succeeded",
+        externalIdentity: { identifier: "wishhq/renamed#7" },
+      },
+    });
+    expect(String(fetchMock.mock.calls[3]?.[0])).toContain(
+      "/repos/wishhq/renamed/issues",
+    );
+  });
+
+  it("marks the connection when GitHub rejects repository access", async () => {
+    const { ids, owner, t } = await seed();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+        .mockResolvedValueOnce(new Response(null, { status: 410 })),
+    );
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    await expect(
+      owner.action(api.workItemHandoffs.send, {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "github",
+      }),
+    ).resolves.toMatchObject({ lifecycle: { state: "failed" } });
+    await expect(t.run(async (ctx) => ctx.db.get(ids.connectionId))).resolves.toMatchObject({
+      health: "needs_attention",
+    });
+  });
+
+  it("marks the connection when GitHub rejects installation-token access", async () => {
+    const { ids, owner, t } = await seed();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+
+    await expect(
+      owner.action(api.workItemHandoffs.send, {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "github",
+      }),
+    ).resolves.toMatchObject({ lifecycle: { state: "failed" } });
+    await expect(t.run(async (ctx) => ctx.db.get(ids.connectionId))).resolves.toMatchObject({
+      health: "needs_attention",
+    });
+  });
+});

--- a/packages/convex-backend/convex/githubWorkItemHandoffs.ts
+++ b/packages/convex-backend/convex/githubWorkItemHandoffs.ts
@@ -1,0 +1,163 @@
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { internalAction, internalMutation, internalQuery } from "./_generated/server";
+import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
+import {
+  createGitHubInstallationToken,
+  GitHubInstallationTokenError,
+} from "./lib/githubApp";
+import { getGitHubAppAuthConfig } from "./lib/githubConnection";
+import { findGitHubIssueBySource } from "./lib/githubIssue";
+import { githubConnectionOrNull } from "./lib/workTrackerConnection";
+
+export const getDeliveryContextInternal = internalQuery({
+  args: { projectId: v.id("projects"), requestId: v.id("requests") },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    const project = await assertProjectOwner(ctx, args.projectId, user._id);
+    const request = await ctx.db.get(args.requestId);
+    if (!request || request.project !== args.projectId) {
+      throw new Error("Request does not belong to the Project Board");
+    }
+    const connection = githubConnectionOrNull(
+      await ctx.db
+        .query("workTrackerConnections")
+        .withIndex("by_project_provider", (q) =>
+          q.eq("projectId", args.projectId).eq("provider", "github"),
+        )
+        .unique(),
+    );
+    return { connection, project, request };
+  },
+});
+
+export const getForReconciliationInternal = internalQuery({
+  args: { handoffId: v.id("workItemHandoffs") },
+  handler: async (ctx, args) => {
+    const handoff = await ctx.db.get(args.handoffId);
+    if (
+      !handoff ||
+      handoff.provider !== "github" ||
+      handoff.recovery.provider !== "github" ||
+      handoff.lifecycle.state !== "unknown"
+    ) {
+      return null;
+    }
+    const connection = githubConnectionOrNull(
+      await ctx.db
+        .query("workTrackerConnections")
+        .withIndex("by_project_provider", (q) =>
+          q.eq("projectId", handoff.projectId).eq("provider", "github"),
+        )
+        .unique(),
+    );
+    if (
+      !connection ||
+      connection.data.installationId !== handoff.recovery.installationId ||
+      connection.data.repository.id !== handoff.recovery.repositoryId
+    ) {
+      return null;
+    }
+    return { connection, handoff };
+  },
+});
+
+export const markConnectionNeedsAttentionInternal = internalMutation({
+  args: {
+    connectionId: v.id("workTrackerConnections"),
+    installationId: v.string(),
+    repositoryId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const connection = githubConnectionOrNull(await ctx.db.get(args.connectionId));
+    if (
+      !connection ||
+      connection.data.installationId !== args.installationId ||
+      connection.data.repository.id !== args.repositoryId
+    ) {
+      return false;
+    }
+    await ctx.db.patch(connection._id, {
+      health: "needs_attention",
+      updatedAt: Math.max(Date.now(), connection.updatedAt + 1),
+    });
+    return true;
+  },
+});
+
+export const reconcileInternal = internalAction({
+  args: { handoffId: v.id("workItemHandoffs") },
+  handler: async (ctx, args): Promise<Doc<"workItemHandoffs"> | null> => {
+    const target = await ctx.runQuery(
+      internal.githubWorkItemHandoffs.getForReconciliationInternal,
+      args,
+    );
+    if (!target || target.handoff.recovery.provider !== "github") return null;
+
+    let accessToken: string;
+    try {
+      accessToken = await createGitHubInstallationToken({
+        config: getGitHubAppAuthConfig(),
+        installationId: target.handoff.recovery.installationId,
+        repositoryIds: [target.handoff.recovery.repositoryId],
+      });
+    } catch (error) {
+      if (error instanceof GitHubInstallationTokenError && error.needsAttention) {
+        await ctx.runMutation(
+          internal.githubWorkItemHandoffs.markConnectionNeedsAttentionInternal,
+          {
+            connectionId: target.connection._id,
+            installationId: target.connection.data.installationId,
+            repositoryId: target.connection.data.repository.id,
+          },
+        );
+      } else {
+        await ctx.runMutation(internal.workItemHandoffs.completeReconciliationInternal, {
+          handoffId: target.handoff._id,
+          expectedReconciliationCount: target.handoff.reconciliationCount,
+        });
+      }
+      return await ctx.runQuery(internal.workItemHandoffs.getByIdInternal, args);
+    }
+
+    const repository = target.connection.data.repository;
+    const result = await findGitHubIssueBySource({
+      accessToken,
+      repository: {
+        id: repository.id,
+        owner: repository.owner,
+        name: repository.name,
+      },
+      sourceUrl: target.handoff.recovery.sourceUrl,
+      startedAt: target.handoff.recovery.startedAt,
+    });
+    console.info("work_item_handoff_reconciliation", {
+      provider: "github",
+      handoffId: target.handoff._id,
+      reconciliationCount:
+        target.handoff.reconciliationCount + (result.needsAttention ? 0 : 1),
+      state: result.needsAttention ? "skipped" : result.state,
+      needsAttention: result.needsAttention,
+    });
+    if (result.needsAttention) {
+      await ctx.runMutation(
+        internal.githubWorkItemHandoffs.markConnectionNeedsAttentionInternal,
+        {
+          connectionId: target.connection._id,
+          installationId: target.connection.data.installationId,
+          repositoryId: target.connection.data.repository.id,
+        },
+      );
+      return await ctx.runQuery(internal.workItemHandoffs.getByIdInternal, args);
+    }
+
+    await ctx.runMutation(internal.workItemHandoffs.completeReconciliationInternal, {
+      handoffId: target.handoff._id,
+      expectedReconciliationCount: target.handoff.reconciliationCount,
+      externalIdentity: result.state === "succeeded" ? result.externalIdentity : undefined,
+    });
+    return await ctx.runQuery(internal.workItemHandoffs.getByIdInternal, args);
+  },
+});

--- a/packages/convex-backend/convex/githubWorkTrackerConnections.test.ts
+++ b/packages/convex-backend/convex/githubWorkTrackerConnections.test.ts
@@ -3,6 +3,7 @@ import { exportPKCS8, generateKeyPair } from "jose";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { api, internal } from "./_generated/api";
+import { unresolvedWorkItemHandoffError } from "./lib/workTrackerErrors";
 import { hashWorkTrackerOAuthState } from "./lib/workTrackerOAuthState";
 import schema from "./schema";
 
@@ -68,6 +69,18 @@ async function seed() {
       user: userId,
       projectSlug: "project",
     });
+    const statusId = await ctx.db.insert("requestStatuses", {
+      name: "open",
+      displayName: "Open",
+      project: projectId,
+      type: "custom",
+    });
+    const requestId = await ctx.db.insert("requests", {
+      text: "Export reports",
+      clientId: "client",
+      status: statusId,
+      project: projectId,
+    });
     const setupId = await ctx.db.insert("workTrackerOAuthSetups", {
       projectId,
       provider: "github",
@@ -85,7 +98,7 @@ async function seed() {
       expiresAt: Date.now() + 60_000,
       consumedAt: 2,
     });
-    return { projectId, setupId, userId };
+    return { projectId, requestId, setupId, userId };
   });
   return { ids, owner: t.withIdentity({ tokenIdentifier: "owner-token" }), t };
 }
@@ -453,6 +466,108 @@ describe("GitHub Work Tracker connections", () => {
         projectId: ids.projectId,
       }),
     ).resolves.toEqual({ disconnected: true });
+  });
+
+  it("blocks destination changes and disconnects while a GitHub Handoff is unresolved", async () => {
+    const { ids, owner, t } = await seed();
+    await owner.mutation(
+      internal.githubWorkTrackerConnections.selectGitHubRepositoryInternal,
+      {
+        projectId: ids.projectId,
+        setupId: ids.setupId,
+        repository: firstRepository,
+        connectionSnapshot: null,
+      },
+    );
+    const connection = await t.run(async (ctx) =>
+      ctx.db
+        .query("workTrackerConnections")
+        .withIndex("by_project_provider", (q) =>
+          q.eq("projectId", ids.projectId).eq("provider", "github"),
+        )
+        .unique(),
+    );
+    if (!connection) throw new Error("Expected GitHub connection");
+    const handoffId = await t.run(async (ctx) =>
+      ctx.db.insert("workItemHandoffs", {
+        projectId: ids.projectId,
+        requestId: ids.requestId,
+        provider: "github",
+        attemptCount: 1,
+        reconciliationCount: 0,
+        recovery: {
+          provider: "github",
+          installationId: "501",
+          repositoryId: firstRepository.id,
+          repositoryOwner: firstRepository.owner,
+          repositoryName: firstRepository.name,
+          sourceUrl: "https://wish.example/source",
+          startedAt: 1,
+        },
+        lifecycle: { state: "pending", leaseExpiresAt: Date.now() + 60_000 },
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+    );
+    const change = (repository: typeof firstRepository, updatedAt = connection.updatedAt) =>
+      owner.mutation(internal.githubWorkTrackerConnections.changeGitHubRepositoryInternal, {
+        projectId: ids.projectId,
+        connectionId: connection._id,
+        installationId: "501",
+        connectionUpdatedAt: updatedAt,
+        repository,
+      });
+
+    await expect(change(firstRepository)).rejects.toMatchObject({
+      data: unresolvedWorkItemHandoffError,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(handoffId, { lifecycle: { state: "unknown" } });
+    });
+    await expect(change(firstRepository)).resolves.toEqual({ repository: firstRepository });
+    const updatedConnection = await t.run(async (ctx) => ctx.db.get(connection._id));
+    if (!updatedConnection) throw new Error("Expected GitHub connection");
+    const replacementSetupId = await t.run(async (ctx) =>
+      ctx.db.insert("workTrackerOAuthSetups", {
+        projectId: ids.projectId,
+        provider: "github",
+        stateHash: "replacement-state",
+        data: {
+          provider: "github",
+          stage: "ready",
+          redirectUri: "https://api.example.com/work-trackers/github/callback",
+          installationId: "502",
+          accountLogin: "wishco",
+          repositories: [firstRepository],
+        },
+        createdBy: ids.userId,
+        createdAt: 2,
+        expiresAt: Date.now() + 60_000,
+        consumedAt: 2,
+      }),
+    );
+    await expect(
+      owner.mutation(
+        internal.githubWorkTrackerConnections.selectGitHubRepositoryInternal,
+        {
+          projectId: ids.projectId,
+          setupId: replacementSetupId,
+          repository: firstRepository,
+          connectionSnapshot: {
+            id: updatedConnection._id,
+            updatedAt: updatedConnection.updatedAt,
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
+    await expect(change(secondRepository, updatedConnection.updatedAt)).rejects.toMatchObject({
+      data: unresolvedWorkItemHandoffError,
+    });
+    await expect(
+      owner.mutation(api.githubWorkTrackerConnections.disconnectGitHub, {
+        projectId: ids.projectId,
+      }),
+    ).rejects.toMatchObject({ data: unresolvedWorkItemHandoffError });
   });
 
   it("marks only the selected repository when GitHub removes access", async () => {

--- a/packages/convex-backend/convex/githubWorkTrackerConnections.ts
+++ b/packages/convex-backend/convex/githubWorkTrackerConnections.ts
@@ -8,6 +8,7 @@ import {
   listGitHubInstallationRepositories,
 } from "./lib/githubApp";
 import { getGitHubAppAuthConfig } from "./lib/githubConnection";
+import { assertNoBlockingWorkTrackerHandoffs } from "./lib/workTrackerGuards";
 import {
   githubConnectionOrNull,
   githubSetupOrNull,
@@ -89,6 +90,17 @@ export const selectGitHubRepositoryInternal = internalMutation({
       : existing === null;
     if (!connectionIsCurrent) {
       throw new Error("GitHub connection changed; reload and try again");
+    }
+    if (existing) {
+      const sameDestination =
+        existing.data.installationId === setup.data.installationId &&
+        existing.data.repository.id === args.repository.id;
+      await assertNoBlockingWorkTrackerHandoffs(
+        ctx,
+        args.projectId,
+        "github",
+        sameDestination,
+      );
     }
     const now = Date.now();
     const data = {
@@ -267,6 +279,12 @@ export const changeGitHubRepositoryInternal = internalMutation({
     ) {
       throw new Error("GitHub connection changed; reload and try again");
     }
+    await assertNoBlockingWorkTrackerHandoffs(
+      ctx,
+      args.projectId,
+      "github",
+      connection.data.repository.id === args.repository.id,
+    );
     await ctx.db.patch(connection._id, {
       health: "active",
       destinationLabel: args.repository.fullName,
@@ -326,7 +344,10 @@ export const disconnectGitHub = mutation({
         )
         .unique(),
     );
-    if (connection) await ctx.db.delete(connection._id);
+    if (connection) {
+      await assertNoBlockingWorkTrackerHandoffs(ctx, args.projectId, "github");
+      await ctx.db.delete(connection._id);
+    }
     return { disconnected: true };
   },
 });

--- a/packages/convex-backend/convex/lib/githubApp.ts
+++ b/packages/convex-backend/convex/lib/githubApp.ts
@@ -2,12 +2,19 @@ import { importPKCS8, SignJWT } from "jose";
 
 import type { getGitHubAppAuthConfig } from "./githubConnection";
 
-const GITHUB_API_URL = "https://api.github.com";
+export const GITHUB_API_URL = "https://api.github.com";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
-const GITHUB_API_VERSION = "2026-03-10";
-const GITHUB_TIMEOUT_MS = 10_000;
+export const GITHUB_API_VERSION = "2026-03-10";
+export const GITHUB_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 1_000_000;
 const MAX_PAGES = 10;
+
+export class GitHubInstallationTokenError extends Error {
+  constructor(public readonly needsAttention: boolean) {
+    super("GitHub installation token request failed");
+    this.name = "GitHubInstallationTokenError";
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -23,7 +30,7 @@ function readId(value: unknown) {
     : null;
 }
 
-async function readGitHubJson(response: Response) {
+export async function readGitHubJson(response: Response) {
   const contentLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
     throw new Error("GitHub response exceeded the size limit");
@@ -51,13 +58,22 @@ async function readGitHubJson(response: Response) {
   }
 }
 
-function githubHeaders(token: string) {
+export function githubHeaders(token: string) {
   return {
     accept: "application/vnd.github+json",
     authorization: `Bearer ${token}`,
     "x-github-api-version": GITHUB_API_VERSION,
     "user-agent": "Wish-Work-Tracker",
   };
+}
+
+export function isGitHubRateLimitedResponse(response: Response) {
+  return (
+    response.status === 429 ||
+    (response.status === 403 &&
+      (response.headers.get("x-ratelimit-remaining") === "0" ||
+        response.headers.has("retry-after")))
+  );
 }
 
 async function githubGet(path: string, token: string) {
@@ -308,7 +324,12 @@ export async function createGitHubInstallationToken(args: {
       signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
     },
   );
-  if (!response.ok) throw new Error("GitHub installation token request failed");
+  if (!response.ok) {
+    throw new GitHubInstallationTokenError(
+      !isGitHubRateLimitedResponse(response) &&
+        (response.status === 403 || response.status === 404 || response.status === 410),
+    );
+  }
   const value = await readGitHubJson(response);
   const token = isRecord(value) ? readString(value.token) : null;
   if (!token) throw new Error("Invalid GitHub installation token response");

--- a/packages/convex-backend/convex/lib/githubConnection.test.ts
+++ b/packages/convex-backend/convex/lib/githubConnection.test.ts
@@ -6,6 +6,7 @@ import {
   getGitHubConfig,
   getGitHubWebhookConfig,
   isGitHubConfigured,
+  isGitHubHandoffCreationEnabled,
   validateGitHubRedirectUri,
 } from "./githubConnection";
 
@@ -77,4 +78,9 @@ describe("GitHub App configuration", () => {
     expect(getGitHubAppAuthConfig()).toMatchObject({ clientId: "Iv1.client" });
   });
 
+  it("enables issue creation only for an explicit true value", () => {
+    expect(isGitHubHandoffCreationEnabled()).toBe(false);
+    vi.stubEnv("GITHUB_HANDOFF_CREATION_ENABLED", " TRUE ");
+    expect(isGitHubHandoffCreationEnabled()).toBe(true);
+  });
 });

--- a/packages/convex-backend/convex/lib/githubConnection.ts
+++ b/packages/convex-backend/convex/lib/githubConnection.ts
@@ -2,7 +2,7 @@ import { importPKCS8 } from "jose";
 
 import {
   getWorkTrackerEncryptionKey,
-  validateWishAppBaseUrl,
+  getWishAppBaseUrl,
 } from "./workTrackerConfig";
 
 export const GITHUB_SETUP_STATE_TTL_MS = 10 * 60 * 1000;
@@ -58,7 +58,7 @@ export function getGitHubConfig() {
     slug,
     redirectUri: validateGitHubRedirectUri(redirectUri),
     webhookSecret,
-    baseUrl: validateWishAppBaseUrl(process.env.WISH_APP_BASE_URL?.trim() ?? ""),
+    baseUrl: getWishAppBaseUrl(),
   };
 }
 
@@ -107,4 +107,8 @@ export async function isGitHubConfigured() {
   } catch {
     return false;
   }
+}
+
+export function isGitHubHandoffCreationEnabled() {
+  return process.env.GITHUB_HANDOFF_CREATION_ENABLED?.trim().toLowerCase() === "true";
 }

--- a/packages/convex-backend/convex/lib/githubHandoffDelivery.ts
+++ b/packages/convex-backend/convex/lib/githubHandoffDelivery.ts
@@ -3,30 +3,34 @@ import { ConvexError } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
-import { getFreshLinearConnection } from "../workTrackerConnections";
 
-import { getLinearConfig, isLinearHandoffCreationEnabled } from "./linearConnection";
-import { createLinearIssue } from "./linearIssue";
+import {
+  createGitHubInstallationToken,
+  GitHubInstallationTokenError,
+} from "./githubApp";
+import {
+  getGitHubAppAuthConfig,
+  isGitHubHandoffCreationEnabled,
+} from "./githubConnection";
+import { createGitHubIssue } from "./githubIssue";
 import { getRequestKind } from "./requestKind";
 import {
   buildWishSourceUrl,
   buildWorkItemDescription,
 } from "./workItemHandoffPayload";
+import { getWishAppBaseUrl } from "./workTrackerConfig";
 import {
   handoffCreationDisabledError,
   workTrackerConnectionNeedsAttentionError,
 } from "./workTrackerErrors";
 
-export async function sendLinearHandoff(
+export async function sendGitHubHandoff(
   ctx: ActionCtx,
   args: { projectId: Id<"projects">; requestId: Id<"requests"> },
 ): Promise<Doc<"workItemHandoffs">> {
   let handoff: Doc<"workItemHandoffs"> | null = await ctx.runQuery(
     internal.workItemHandoffs.getOwnedInternal,
-    {
-      ...args,
-      provider: "linear",
-    },
+    { ...args, provider: "github" },
   );
   if (handoff?.lifecycle.state === "pending") {
     await ctx.runMutation(internal.workItemHandoffs.expirePendingInternal, {
@@ -35,23 +39,29 @@ export async function sendLinearHandoff(
     });
     handoff = await ctx.runQuery(internal.workItemHandoffs.getOwnedInternal, {
       ...args,
-      provider: "linear",
+      provider: "github",
     });
   }
   if (handoff && handoff.lifecycle.state !== "failed") return handoff;
-  if (!isLinearHandoffCreationEnabled()) {
+  if (!isGitHubHandoffCreationEnabled()) {
     throw new ConvexError(handoffCreationDisabledError);
   }
 
-  const config = getLinearConfig();
-  const currentConnection = await ctx.runQuery(
-    internal.workTrackerConnections.getLinearConnectionForActionInternal,
-    { projectId: args.projectId },
+  const context = await ctx.runQuery(
+    internal.githubWorkItemHandoffs.getDeliveryContextInternal,
+    { projectId: args.projectId, requestId: args.requestId },
   );
-  if (!currentConnection || currentConnection.health !== "active") {
+  if (!context.connection || context.connection.health !== "active") {
     throw new ConvexError(workTrackerConnectionNeedsAttentionError);
   }
-
+  const sourceUrl = buildWishSourceUrl(
+    getWishAppBaseUrl(),
+    context.project._id,
+    context.project.projectSlug,
+    getRequestKind(context.request),
+    context.request._id,
+  );
+  const repository = context.connection.data.repository;
   const reservation: {
     handoff: Doc<"workItemHandoffs">;
     shouldSend: boolean;
@@ -59,79 +69,84 @@ export async function sendLinearHandoff(
     request: Doc<"requests">;
   } = await ctx.runMutation(internal.workItemHandoffs.reserveInternal, {
     ...args,
-    provider: "linear",
-    connectionId: currentConnection._id,
-    connectionUpdatedAt: currentConnection.updatedAt,
-    recovery: { provider: "linear", issueId: crypto.randomUUID() },
+    provider: "github",
+    connectionId: context.connection._id,
+    connectionUpdatedAt: context.connection.updatedAt,
+    recovery: {
+      provider: "github",
+      installationId: context.connection.data.installationId,
+      repositoryId: repository.id,
+      repositoryOwner: repository.owner,
+      repositoryName: repository.name,
+      sourceUrl,
+      startedAt: Date.now(),
+    },
   });
-  if (!reservation.shouldSend || reservation.handoff.recovery.provider !== "linear") {
+  if (!reservation.shouldSend || reservation.handoff.recovery.provider !== "github") {
     return reservation.handoff;
   }
 
-  let freshConnection: Awaited<ReturnType<typeof getFreshLinearConnection>> | undefined;
+  let accessToken: string;
   try {
-    freshConnection = await getFreshLinearConnection(ctx, args.projectId);
-  } catch {
-    // The stable failure is persisted below.
-  }
-  if (
-    !freshConnection ||
-    freshConnection.connection._id !== currentConnection._id ||
-    freshConnection.connection.health !== "active"
-  ) {
+    accessToken = await createGitHubInstallationToken({
+      config: getGitHubAppAuthConfig(),
+      installationId: reservation.handoff.recovery.installationId,
+      repositoryIds: [reservation.handoff.recovery.repositoryId],
+    });
+  } catch (error) {
+    if (error instanceof GitHubInstallationTokenError && error.needsAttention) {
+      await ctx.runMutation(
+        internal.githubWorkItemHandoffs.markConnectionNeedsAttentionInternal,
+        {
+          connectionId: context.connection._id,
+          installationId: context.connection.data.installationId,
+          repositoryId: repository.id,
+        },
+      );
+    }
     await ctx.runMutation(internal.workItemHandoffs.completeFailedInternal, {
       handoffId: reservation.handoff._id,
       attemptCount: reservation.handoff.attemptCount,
-      errorCode: "linear_connection_unavailable",
-      errorMessage: "Linear connection is unavailable",
-    });
-    console.info("work_item_handoff_delivery", {
-      provider: "linear",
-      handoffId: reservation.handoff._id,
-      state: "failed",
-      errorCode: "linear_connection_unavailable",
+      errorCode: "github_connection_unavailable",
+      errorMessage: "GitHub connection is unavailable",
     });
     const failed = await ctx.runQuery(internal.workItemHandoffs.getOwnedInternal, {
       ...args,
-      provider: "linear",
+      provider: "github",
     });
     if (!failed) throw new Error("Work Item Handoff was not saved");
     return failed;
   }
-  const { connection, credentials } = freshConnection;
 
-  const sourceUrl = buildWishSourceUrl(
-    config.baseUrl,
-    reservation.project._id,
-    reservation.project.projectSlug,
-    getRequestKind(reservation.request),
-    reservation.request._id,
-  );
-  const result = await createLinearIssue({
-    accessToken: credentials.accessToken,
-    issueId: reservation.handoff.recovery.issueId,
-    teamId: connection.data.teamId,
+  const result = await createGitHubIssue({
+    accessToken,
+    repository: {
+      id: reservation.handoff.recovery.repositoryId,
+      owner: reservation.handoff.recovery.repositoryOwner,
+      name: reservation.handoff.recovery.repositoryName,
+    },
     title: reservation.request.text,
-    description: buildWorkItemDescription(reservation.request.description, sourceUrl),
+    body: buildWorkItemDescription(reservation.request.description, sourceUrl),
   });
   console.info("work_item_handoff_delivery", {
-    provider: "linear",
+    provider: "github",
     handoffId: reservation.handoff._id,
     state: result.state,
     errorCode: result.state === "succeeded" ? undefined : result.errorCode,
-    providerCorrelationId: result.state === "succeeded" ? undefined : result.providerCorrelationId,
+    providerCorrelationId:
+      result.state === "succeeded" ? undefined : result.providerCorrelationId,
   });
 
   if (result.needsAttention) {
     await ctx.runMutation(
-      internal.workTrackerConnections.markLinearConnectionNeedsAttentionInternal,
+      internal.githubWorkItemHandoffs.markConnectionNeedsAttentionInternal,
       {
-        connectionId: connection._id,
-        credentialCiphertext: connection.data.encryptedCredentials.ciphertext,
+        connectionId: context.connection._id,
+        installationId: context.connection.data.installationId,
+        repositoryId: repository.id,
       },
     );
   }
-
   if (result.state === "succeeded") {
     await ctx.runMutation(internal.workItemHandoffs.completeSucceededInternal, {
       handoffId: reservation.handoff._id,
@@ -158,7 +173,7 @@ export async function sendLinearHandoff(
 
   const saved = await ctx.runQuery(internal.workItemHandoffs.getOwnedInternal, {
     ...args,
-    provider: "linear",
+    provider: "github",
   });
   if (!saved) throw new Error("Work Item Handoff was not saved");
   return saved;

--- a/packages/convex-backend/convex/lib/githubIssue.test.ts
+++ b/packages/convex-backend/convex/lib/githubIssue.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createGitHubIssue, findGitHubIssueBySource } from "./githubIssue";
+
+const repository = { id: "101", owner: "wishco", name: "product" };
+const issue = {
+  id: 42,
+  node_id: "I_42",
+  number: 7,
+  html_url: "https://github.com/wishco/product/issues/7",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GitHub issue delivery", () => {
+  it("creates an issue with the minimum payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(issue, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createGitHubIssue({
+        accessToken: "installation-token",
+        repository,
+        title: "Export reports",
+        body: "Description with source link",
+      }),
+    ).resolves.toEqual({
+      state: "succeeded",
+      needsAttention: false,
+      externalIdentity: {
+        provider: "github",
+        id: "42",
+        nodeId: "I_42",
+        number: 7,
+        repositoryId: "101",
+        identifier: "wishco/product#7",
+        url: "https://github.com/wishco/product/issues/7",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/wishco/product/issues",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Export reports",
+          body: "Description with source link",
+        }),
+      }),
+    );
+  });
+
+  it("distinguishes unknown outcomes from definite connection failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response(null, { status: 503 }))
+        .mockResolvedValueOnce(new Response(null, { status: 410 }))
+        .mockResolvedValueOnce(new Response(null, { status: 403 }))
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 403,
+            headers: { "x-ratelimit-remaining": "0" },
+          }),
+        ),
+    );
+    const args = {
+      accessToken: "installation-token",
+      repository,
+      title: "Export reports",
+      body: "Description",
+    };
+
+    await expect(createGitHubIssue(args)).resolves.toMatchObject({
+      state: "unknown",
+      needsAttention: false,
+    });
+    await expect(createGitHubIssue(args)).resolves.toMatchObject({
+      state: "failed",
+      errorCode: "github_connection_invalid",
+      needsAttention: true,
+    });
+    await expect(createGitHubIssue(args)).resolves.toMatchObject({
+      errorCode: "github_connection_invalid",
+      needsAttention: true,
+    });
+    await expect(createGitHubIssue(args)).resolves.toMatchObject({
+      errorCode: "github_rate_limited",
+      needsAttention: false,
+    });
+  });
+
+  it("finds the exact Wish source marker and ignores pull requests", async () => {
+    const sourceUrl = "https://wish.example/dashboard/project/p/project/requests?item=r";
+    const createdAt = new Date().toISOString();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            ...issue,
+            number: 6,
+            html_url: "https://github.com/wishco/product/issues/6",
+            body: `[View original in Wish](${sourceUrl})`,
+            created_at: createdAt,
+            pull_request: {},
+          },
+          { body: "First unrelated issue", created_at: createdAt },
+          { body: "Second unrelated issue", created_at: createdAt },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            ...issue,
+            body: `Description\n\n---\n\n[View original in Wish](${sourceUrl})`,
+            created_at: createdAt,
+          },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      findGitHubIssueBySource({
+        accessToken: "installation-token",
+        repository,
+        sourceUrl,
+        startedAt: Date.now() - 1_000,
+      }),
+    ).resolves.toMatchObject({
+      state: "succeeded",
+      externalIdentity: { identifier: "wishco/product#7" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("per_page=3");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("page=2");
+  });
+
+  it("confirms absence only after scanning past the creation window", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json([
+          {
+            ...issue,
+            body: "Unrelated issue",
+            created_at: new Date(0).toISOString(),
+          },
+        ]),
+      ),
+    );
+
+    await expect(
+      findGitHubIssueBySource({
+        accessToken: "installation-token",
+        repository,
+        sourceUrl: "https://wish.example/source",
+        startedAt: Date.now(),
+      }),
+    ).resolves.toEqual({ state: "absent", needsAttention: false });
+  });
+});

--- a/packages/convex-backend/convex/lib/githubIssue.ts
+++ b/packages/convex-backend/convex/lib/githubIssue.ts
@@ -1,0 +1,240 @@
+import {
+  GITHUB_API_URL,
+  GITHUB_API_VERSION,
+  GITHUB_TIMEOUT_MS,
+  githubHeaders,
+  isGitHubRateLimitedResponse,
+  readGitHubJson,
+} from "./githubApp";
+
+const RECONCILIATION_PAGE_SIZE = 3;
+const MAX_RECONCILIATION_PAGES = 34;
+const RECONCILIATION_CLOCK_SAFETY_MS = 5_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, maxLength: number) {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength
+    ? value
+    : undefined;
+}
+
+function readPositiveInteger(value: unknown) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function readCorrelationId(response: Response) {
+  const value = response.headers.get("x-github-request-id");
+  return value && /^[A-Za-z0-9._:-]{1,200}$/.test(value) ? value : undefined;
+}
+
+function readGitHubIssueIdentity(
+  value: unknown,
+  repository: { id: string; owner: string; name: string },
+) {
+  if (!isRecord(value)) return;
+  const id = readPositiveInteger(value.id);
+  const nodeId = readString(value.node_id, 200);
+  const number = readPositiveInteger(value.number);
+  const urlValue = readString(value.html_url, 2_000);
+  if (!id || !nodeId || !number || !urlValue) return;
+  try {
+    const url = new URL(urlValue);
+    const expectedPath = `/${repository.owner}/${repository.name}/issues/${number}`;
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== "github.com" ||
+      url.pathname.toLowerCase() !== expectedPath.toLowerCase() ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    ) {
+      return;
+    }
+    return {
+      provider: "github" as const,
+      id: String(id),
+      nodeId,
+      number,
+      repositoryId: repository.id,
+      identifier: `${repository.owner}/${repository.name}#${number}`,
+      url: url.toString(),
+    };
+  } catch {
+    return;
+  }
+}
+
+function unknownResult(correlationId?: string) {
+  return {
+    state: "unknown" as const,
+    errorCode: "github_outcome_unknown",
+    errorMessage: "Wish could not confirm whether GitHub created the issue",
+    providerCorrelationId: correlationId,
+    needsAttention: false,
+  };
+}
+
+function failedResult(
+  errorCode: string,
+  errorMessage: string,
+  correlationId?: string,
+  needsAttention = false,
+) {
+  return {
+    state: "failed" as const,
+    errorCode,
+    errorMessage,
+    providerCorrelationId: correlationId,
+    needsAttention,
+  };
+}
+
+function issueUrl(owner: string, repository: string) {
+  return `${GITHUB_API_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/issues`;
+}
+
+export async function createGitHubIssue(args: {
+  accessToken: string;
+  repository: { id: string; owner: string; name: string };
+  title: string;
+  body: string;
+}) {
+  let response: Response;
+  try {
+    response = await fetch(issueUrl(args.repository.owner, args.repository.name), {
+      method: "POST",
+      headers: { ...githubHeaders(args.accessToken), "content-type": "application/json" },
+      body: JSON.stringify({ title: args.title, body: args.body }),
+      signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+    });
+  } catch {
+    return unknownResult();
+  }
+
+  const correlationId = readCorrelationId(response);
+  if (response.status >= 500) return unknownResult(correlationId);
+  if (
+    response.status === 401 ||
+    response.status === 403 ||
+    response.status === 404 ||
+    response.status === 410
+  ) {
+    if (isGitHubRateLimitedResponse(response)) {
+      return failedResult(
+        "github_rate_limited",
+        "GitHub rate limited the issue request",
+        correlationId,
+      );
+    }
+    return failedResult(
+      "github_connection_invalid",
+      "GitHub rejected the connection or repository",
+      correlationId,
+      true,
+    );
+  }
+  if (response.status === 429) {
+    return failedResult(
+      "github_rate_limited",
+      "GitHub rate limited the issue request",
+      correlationId,
+    );
+  }
+  if (response.status === 422) {
+    return failedResult("github_rejected", "GitHub rejected the issue", correlationId);
+  }
+  if (response.status !== 201) {
+    return response.status >= 400
+      ? failedResult("github_rejected", "GitHub rejected the issue", correlationId)
+      : unknownResult(correlationId);
+  }
+
+  let body: unknown;
+  try {
+    body = await readGitHubJson(response);
+  } catch {
+    return unknownResult(correlationId);
+  }
+  const externalIdentity = readGitHubIssueIdentity(body, args.repository);
+  return externalIdentity
+    ? { state: "succeeded" as const, externalIdentity, needsAttention: false }
+    : unknownResult(correlationId);
+}
+
+export async function findGitHubIssueBySource(args: {
+  accessToken: string;
+  repository: { id: string; owner: string; name: string };
+  sourceUrl: string;
+  startedAt: number;
+}) {
+  const sourceMarker = `[View original in Wish](${args.sourceUrl})`;
+  const cutoff = args.startedAt - RECONCILIATION_CLOCK_SAFETY_MS;
+  for (let page = 1; page <= MAX_RECONCILIATION_PAGES; page += 1) {
+    const url = new URL(issueUrl(args.repository.owner, args.repository.name));
+    url.searchParams.set("state", "all");
+    url.searchParams.set("sort", "created");
+    url.searchParams.set("direction", "desc");
+    // ponytail: small pages keep full issue bodies below the shared 1 MB cap.
+    url.searchParams.set("per_page", String(RECONCILIATION_PAGE_SIZE));
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("since", new Date(cutoff).toISOString());
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: githubHeaders(args.accessToken),
+        signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+      });
+    } catch {
+      return { state: "unknown" as const, needsAttention: false };
+    }
+    if (
+      response.status === 401 ||
+      response.status === 403 ||
+      response.status === 404 ||
+      response.status === 410
+    ) {
+      return {
+        state: "unknown" as const,
+        needsAttention: !isGitHubRateLimitedResponse(response),
+      };
+    }
+    if (!response.ok) return { state: "unknown" as const, needsAttention: false };
+
+    let body: unknown;
+    try {
+      body = await readGitHubJson(response);
+    } catch {
+      return { state: "unknown" as const, needsAttention: false };
+    }
+    if (!Array.isArray(body)) {
+      return { state: "unknown" as const, needsAttention: false };
+    }
+    for (const issue of body) {
+      if (!isRecord(issue)) return { state: "unknown" as const, needsAttention: false };
+      const createdAtValue = readString(issue.created_at, 100);
+      const createdAt = createdAtValue ? Date.parse(createdAtValue) : Number.NaN;
+      if (!Number.isFinite(createdAt)) {
+        return { state: "unknown" as const, needsAttention: false };
+      }
+      if (createdAt < cutoff) return { state: "absent" as const, needsAttention: false };
+      if (issue.pull_request !== undefined) continue;
+      if (typeof issue.body === "string" && issue.body.includes(sourceMarker)) {
+        const externalIdentity = readGitHubIssueIdentity(issue, args.repository);
+        return externalIdentity
+          ? { state: "succeeded" as const, externalIdentity, needsAttention: false }
+          : { state: "unknown" as const, needsAttention: false };
+      }
+    }
+    if (body.length < RECONCILIATION_PAGE_SIZE) {
+      return { state: "absent" as const, needsAttention: false };
+    }
+  }
+  return { state: "unknown" as const, needsAttention: false };
+}

--- a/packages/convex-backend/convex/lib/linearConnection.ts
+++ b/packages/convex-backend/convex/lib/linearConnection.ts
@@ -1,6 +1,6 @@
 import {
   getWorkTrackerEncryptionKey,
-  validateWishAppBaseUrl,
+  getWishAppBaseUrl,
 } from "./workTrackerConfig";
 
 export const LINEAR_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
@@ -35,13 +35,12 @@ export function getLinearConfig() {
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error("Linear OAuth is not configured");
   }
-  const baseUrl = validateWishAppBaseUrl(process.env.WISH_APP_BASE_URL?.trim() ?? "");
   return {
     clientId,
     clientSecret,
     redirectUri: validateLinearRedirectUri(redirectUri),
     encryptionKey: getWorkTrackerEncryptionKey(),
-    baseUrl,
+    baseUrl: getWishAppBaseUrl(),
   };
 }
 

--- a/packages/convex-backend/convex/lib/linearIssue.test.ts
+++ b/packages/convex-backend/convex/lib/linearIssue.test.ts
@@ -1,35 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import {
-  buildLinearIssueDescription,
-  buildWishSourceUrl,
-  createLinearIssue,
-  findLinearIssue,
-} from "./linearIssue";
+import { createLinearIssue, findLinearIssue } from "./linearIssue";
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("Linear issue delivery", () => {
-  it("builds owner deep links and copies only the agreed description", () => {
-    const sourceUrl = buildWishSourceUrl(
-      "https://wish.example.com",
-      "project-id",
-      "product-roadmap",
-      "complaint",
-      "request-id",
-    );
-
-    expect(sourceUrl).toBe(
-      "https://wish.example.com/dashboard/project/project-id/product-roadmap/complaints?item=request-id",
-    );
-    expect(buildLinearIssueDescription("Original description", sourceUrl)).toBe(
-      `Original description\n\n---\n\n[View original in Wish](${sourceUrl})`,
-    );
-    expect(buildLinearIssueDescription(undefined, sourceUrl)).toBe(
-      `[View original in Wish](${sourceUrl})`,
-    );
-  });
-
   it("creates an issue with the preallocated id and minimum payload", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       Response.json({

--- a/packages/convex-backend/convex/lib/linearIssue.ts
+++ b/packages/convex-backend/convex/lib/linearIssue.ts
@@ -104,27 +104,6 @@ async function requestLinear(accessToken: string, query: string, variables: unkn
   });
 }
 
-export function buildLinearIssueDescription(description: string | undefined, sourceUrl: string) {
-  const sourceLink = `[View original in Wish](${sourceUrl})`;
-  return description ? `${description}\n\n---\n\n${sourceLink}` : sourceLink;
-}
-
-export function buildWishSourceUrl(
-  baseUrl: string,
-  projectId: string,
-  projectSlug: string | undefined,
-  kind: "request" | "complaint",
-  requestId: string,
-) {
-  const source = kind === "complaint" ? "complaints" : "requests";
-  const path = ["dashboard", "project", projectId, projectSlug ?? "project", source]
-    .map(encodeURIComponent)
-    .join("/");
-  const url = new URL(`/${path}`, baseUrl);
-  url.searchParams.set("item", requestId);
-  return url.toString();
-}
-
 export async function createLinearIssue(args: {
   accessToken: string;
   issueId: string;

--- a/packages/convex-backend/convex/lib/workItemHandoffPayload.test.ts
+++ b/packages/convex-backend/convex/lib/workItemHandoffPayload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildWishSourceUrl,
+  buildWorkItemDescription,
+} from "./workItemHandoffPayload";
+
+describe("Work Item Handoff payload", () => {
+  it("builds owner deep links and copies only the agreed description", () => {
+    const sourceUrl = buildWishSourceUrl(
+      "https://wish.example.com",
+      "project-id",
+      "product-roadmap",
+      "complaint",
+      "request-id",
+    );
+
+    expect(sourceUrl).toBe(
+      "https://wish.example.com/dashboard/project/project-id/product-roadmap/complaints?item=request-id",
+    );
+    expect(buildWorkItemDescription("Original description", sourceUrl)).toBe(
+      `Original description\n\n---\n\n[View original in Wish](${sourceUrl})`,
+    );
+    expect(buildWorkItemDescription(undefined, sourceUrl)).toBe(
+      `[View original in Wish](${sourceUrl})`,
+    );
+  });
+});

--- a/packages/convex-backend/convex/lib/workItemHandoffPayload.ts
+++ b/packages/convex-backend/convex/lib/workItemHandoffPayload.ts
@@ -1,0 +1,23 @@
+export function buildWorkItemDescription(
+  description: string | undefined,
+  sourceUrl: string,
+) {
+  const sourceLink = `[View original in Wish](${sourceUrl})`;
+  return description ? `${description}\n\n---\n\n${sourceLink}` : sourceLink;
+}
+
+export function buildWishSourceUrl(
+  baseUrl: string,
+  projectId: string,
+  projectSlug: string | undefined,
+  kind: "request" | "complaint",
+  requestId: string,
+) {
+  const source = kind === "complaint" ? "complaints" : "requests";
+  const path = ["dashboard", "project", projectId, projectSlug ?? "project", source]
+    .map(encodeURIComponent)
+    .join("/");
+  const url = new URL(`/${path}`, baseUrl);
+  url.searchParams.set("item", requestId);
+  return url.toString();
+}

--- a/packages/convex-backend/convex/lib/workTrackerConfig.test.ts
+++ b/packages/convex-backend/convex/lib/workTrackerConfig.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  getWishAppBaseUrl,
   getWorkTrackerEncryptionKey,
   validateWishAppBaseUrl,
 } from "./workTrackerConfig";
@@ -28,5 +29,11 @@ describe("Work Tracker configuration", () => {
     vi.stubEnv("WORK_TRACKER_ENCRYPTION_KEY", encryptionKey);
 
     expect(getWorkTrackerEncryptionKey()).toBe(encryptionKey);
+  });
+
+  it("loads the canonical Wish origin", () => {
+    vi.stubEnv("WISH_APP_BASE_URL", "https://wish.example.com/");
+
+    expect(getWishAppBaseUrl()).toBe("https://wish.example.com");
   });
 });

--- a/packages/convex-backend/convex/lib/workTrackerConfig.ts
+++ b/packages/convex-backend/convex/lib/workTrackerConfig.ts
@@ -27,3 +27,7 @@ export function getWorkTrackerEncryptionKey() {
   if (!encryptionKey) throw new Error("Work Tracker encryption key is not configured");
   return validateWorkTrackerEncryptionKey(encryptionKey);
 }
+
+export function getWishAppBaseUrl() {
+  return validateWishAppBaseUrl(process.env.WISH_APP_BASE_URL?.trim() ?? "");
+}

--- a/packages/convex-backend/convex/lib/workTrackerErrors.ts
+++ b/packages/convex-backend/convex/lib/workTrackerErrors.ts
@@ -5,10 +5,10 @@ export const unresolvedWorkItemHandoffError = {
 
 export const handoffCreationDisabledError = {
   code: "WORK_ITEM_HANDOFF_CREATION_DISABLED",
-  message: "Linear delivery is temporarily disabled",
+  message: "Work Tracker delivery is temporarily disabled",
 } as const;
 
 export const workTrackerConnectionNeedsAttentionError = {
   code: "WORK_TRACKER_CONNECTION_NEEDS_ATTENTION",
-  message: "Fix the Linear connection before sending",
+  message: "Fix the Work Tracker connection before sending",
 } as const;

--- a/packages/convex-backend/convex/lib/workTrackerTypes.ts
+++ b/packages/convex-backend/convex/lib/workTrackerTypes.ts
@@ -5,7 +5,10 @@ export const workTrackerConnectionProviderValidator = v.union(
   v.literal("github"),
 );
 
-export const workTrackerProviderValidator = v.literal("linear");
+export const workTrackerProviderValidator = v.union(
+  v.literal("linear"),
+  v.literal("github"),
+);
 
 export const workTrackerConnectionHealthValidator = v.union(
   v.literal("active"),
@@ -118,17 +121,39 @@ export const workTrackerOAuthSetupDataValidator = v.union(
   }),
 );
 
-export const workItemHandoffRecoveryValidator = v.object({
-  provider: v.literal("linear"),
-  issueId: v.string(),
-});
+export const workItemHandoffRecoveryValidator = v.union(
+  v.object({
+    provider: v.literal("linear"),
+    issueId: v.string(),
+  }),
+  v.object({
+    provider: v.literal("github"),
+    installationId: v.string(),
+    repositoryId: v.string(),
+    repositoryOwner: v.string(),
+    repositoryName: v.string(),
+    sourceUrl: v.string(),
+    startedAt: v.number(),
+  }),
+);
 
-export const externalWorkItemIdentityValidator = v.object({
-  provider: v.literal("linear"),
-  id: v.string(),
-  identifier: v.string(),
-  url: v.string(),
-});
+export const externalWorkItemIdentityValidator = v.union(
+  v.object({
+    provider: v.literal("linear"),
+    id: v.string(),
+    identifier: v.string(),
+    url: v.string(),
+  }),
+  v.object({
+    provider: v.literal("github"),
+    id: v.string(),
+    nodeId: v.string(),
+    number: v.number(),
+    repositoryId: v.string(),
+    identifier: v.string(),
+    url: v.string(),
+  }),
+);
 
 const handoffErrorFields = {
   errorCode: v.optional(v.string()),

--- a/packages/convex-backend/convex/linearWorkItemHandoffs.ts
+++ b/packages/convex-backend/convex/linearWorkItemHandoffs.ts
@@ -17,7 +17,12 @@ export const getForReconciliationInternal = internalQuery({
   args: { handoffId: v.id("workItemHandoffs") },
   handler: async (ctx, args) => {
     const handoff = await ctx.db.get(args.handoffId);
-    if (!handoff || handoff.provider !== "linear" || handoff.lifecycle.state !== "unknown") {
+    if (
+      !handoff ||
+      handoff.provider !== "linear" ||
+      handoff.recovery.provider !== "linear" ||
+      handoff.lifecycle.state !== "unknown"
+    ) {
       return null;
     }
     const connection = linearConnectionOrNull(
@@ -57,7 +62,7 @@ export const reconcileInternal = internalAction({
       internal.linearWorkItemHandoffs.getForReconciliationInternal,
       args,
     );
-    if (!target) return null;
+    if (!target || target.handoff.recovery.provider !== "linear") return null;
 
     let accessToken: string | undefined;
     let credentialCiphertext = target.connection.data.encryptedCredentials.ciphertext;

--- a/packages/convex-backend/convex/workItemHandoffs.test.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.test.ts
@@ -424,6 +424,12 @@ describe("Work Item Handoff delivery lifecycle", () => {
     ]);
 
     expect(second.handoff._id).toBe(first.handoff._id);
+    if (
+      first.handoff.recovery.provider !== "linear" ||
+      second.handoff.recovery.provider !== "linear"
+    ) {
+      throw new Error("Expected Linear recovery data");
+    }
     expect(second.handoff.recovery.issueId).toBe(first.handoff.recovery.issueId);
     expect([first.shouldSend, second.shouldSend].sort()).toEqual([false, true]);
     expect(
@@ -431,7 +437,7 @@ describe("Work Item Handoff delivery lifecycle", () => {
     ).toHaveLength(1);
   });
 
-  it("retries a definite failure with the same provider id", async () => {
+  it("retries a definite failure with fresh recovery data", async () => {
     const { ids, owner } = await seed();
     const first = await owner.mutation(
       internal.workItemHandoffs.reserveInternal,
@@ -450,7 +456,10 @@ describe("Work Item Handoff delivery lifecycle", () => {
     );
     expect(retry.shouldSend).toBe(true);
     expect(retry.handoff.attemptCount).toBe(2);
-    expect(retry.handoff.recovery.issueId).toBe("stable-issue-id");
+    if (retry.handoff.recovery.provider !== "linear") {
+      throw new Error("Expected Linear recovery data");
+    }
+    expect(retry.handoff.recovery.issueId).toBe("different-issue-id");
   });
 
   it("moves an expired pending attempt to unknown instead of retrying creation", async () => {

--- a/packages/convex-backend/convex/workItemHandoffs.ts
+++ b/packages/convex-backend/convex/workItemHandoffs.ts
@@ -11,6 +11,7 @@ import {
   query,
 } from "./_generated/server";
 import { assertProjectOwner, getCurrentUser } from "./lib/authorization";
+import { sendGitHubHandoff } from "./lib/githubHandoffDelivery";
 import { sendLinearHandoff } from "./lib/linearHandoffDelivery";
 import {
   WORK_ITEM_HANDOFF_RECONCILIATION_DELAYS_MS,
@@ -190,6 +191,7 @@ export const reserveInternal = internalMutation({
       await ctx.db.patch(existing._id, {
         attemptCount,
         reconciliationCount: 0,
+        recovery: args.recovery,
         lifecycle,
         updatedAt: now,
       });
@@ -389,6 +391,8 @@ export const send = action({
     switch (args.provider) {
       case "linear":
         return await sendLinearHandoff(ctx, args);
+      case "github":
+        return await sendGitHubHandoff(ctx, args);
     }
   },
 });
@@ -405,6 +409,8 @@ export const reconcileInternal = internalAction({
     switch (handoff.provider) {
       case "linear":
         return await ctx.runAction(internal.linearWorkItemHandoffs.reconcileInternal, args);
+      case "github":
+        return await ctx.runAction(internal.githubWorkItemHandoffs.reconcileInternal, args);
     }
   },
 });


### PR DESCRIPTION
## Summary

- route provider-neutral Work Item Handoffs to GitHub Issues and persist the issue link
- reconcile uncertain outcomes by the canonical Wish source link without blind creation retries
- block unsafe repository changes and disconnects while GitHub Handoffs are unresolved
- document the GitHub delivery emergency flag

## Validation

- bun run check-types
- bun run lint
- bun run test (171 tests)
- bun run build
- git diff --check
- thermo-nuclear review: approved
- review loop: approved

## Stack

Depends on #69.