### PR TITLE
feat: add unified Work Tracker UI

### DIFF
--- a/apps/wish-start/src/components/Organisms/AppSidebar.test.tsx
+++ b/apps/wish-start/src/components/Organisms/AppSidebar.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const routing = vi.hoisted(() => ({
+  replace: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useLocation: () => ({
+    pathname: "/dashboard",
+    searchStr: "?settings=work-trackers&github=invalid_state",
+  }),
+  useParams: () => ({}),
+  useRouter: () => ({ history: { replace: routing.replace } }),
+}));
+
+vi.mock("@/components/project/ProjectSettings", () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+import { AppSidebar } from "./AppSidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppSidebar Work Tracker callbacks", () => {
+  it("shows no-project callback feedback and cleans its routing state on dismiss", () => {
+    render(
+      <SidebarProvider>
+        <AppSidebar />
+      </SidebarProvider>,
+    );
+
+    expect(screen.getByText("This GitHub connection link expired")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(routing.replace).toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/apps/wish-start/src/components/Organisms/AppSidebar.tsx
+++ b/apps/wish-start/src/components/Organisms/AppSidebar.tsx
@@ -14,7 +14,13 @@ import {
 import type { ReactNode } from "react";
 
 import ProjectSettings from "@/components/project/ProjectSettings";
+import { WorkTrackerCallbackAlert } from "@/components/project/WorkTrackerSetup";
+import { parseGitHubCallbackResult } from "@/lib/githubWorkTrackerUi";
 import { parseLinearCallbackResult } from "@/lib/linearWorkTrackerUi";
+import {
+  getWorkTrackerCallbackDismissUrl,
+  getWorkTrackerCallbackMessage,
+} from "@/lib/workTrackerCallbackUi";
 import {
   Sidebar,
   SidebarContent,
@@ -79,6 +85,14 @@ export function AppSidebar({ footer }: Props) {
   const location = useLocation();
   const router = useRouter();
   const search = new URLSearchParams(location.searchStr);
+  const githubResult = parseGitHubCallbackResult(search.get("github"));
+  const linearResult = parseLinearCallbackResult(search.get("linear"));
+
+  function clearCallbackResult(provider: "github" | "linear") {
+    router.history.replace(
+      getWorkTrackerCallbackDismissUrl(location.pathname, location.searchStr, provider),
+    );
+  }
 
   return (
     <Sidebar variant="floating" className="z-20">
@@ -88,16 +102,22 @@ export function AppSidebar({ footer }: Props) {
             projectId={projectId}
             slug={slug}
             requestedSettings={search.get("settings") === "work-trackers" ? "work-trackers" : undefined}
-            linearResult={parseLinearCallbackResult(search.get("linear"))}
+            githubResult={githubResult}
+            linearResult={linearResult}
             onSettingsClose={() => {
               search.delete("settings");
+              search.delete("github");
               search.delete("linear");
               const suffix = search.toString();
               router.history.replace(`${location.pathname}${suffix ? `?${suffix}` : ""}`);
             }}
           />
         ) : (
-          <GlobalNav />
+          <GlobalNav
+            githubResult={githubResult}
+            linearResult={linearResult}
+            onDismiss={clearCallbackResult}
+          />
         )}
       </SidebarContent>
       <SidebarFooter>{footer}</SidebarFooter>
@@ -105,35 +125,68 @@ export function AppSidebar({ footer }: Props) {
   );
 }
 
-function GlobalNav() {
+function GlobalNav({
+  githubResult,
+  linearResult,
+  onDismiss,
+}: {
+  githubResult?: string;
+  linearResult?: string;
+  onDismiss: (provider: "github" | "linear") => void;
+}) {
+  const githubMessage = getWorkTrackerCallbackMessage("github", githubResult);
+  const linearMessage = getWorkTrackerCallbackMessage("linear", linearResult);
+
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel>Wish App</SidebarGroupLabel>
-      <SidebarGroupContent>
-        <SidebarMenu>
-          {items.map((item) => (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton asChild>
-                <Link to={item.url}>
-                  <item.icon />
-                  <span>{item.title}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
+    <>
+      {githubMessage || linearMessage ? (
+        <SidebarGroup>
+          <div className="space-y-2">
+            {githubMessage ? (
+              <WorkTrackerCallbackAlert
+                {...githubMessage}
+                onDismiss={() => onDismiss("github")}
+              />
+            ) : null}
+            {linearMessage ? (
+              <WorkTrackerCallbackAlert
+                {...linearMessage}
+                onDismiss={() => onDismiss("linear")}
+              />
+            ) : null}
+          </div>
+        </SidebarGroup>
+      ) : null}
+      <SidebarGroup>
+        <SidebarGroupLabel>Wish App</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {items.map((item) => (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild>
+                  <Link to={item.url}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </>
   );
 }
 
 function ProjectNav({
+  githubResult,
   linearResult,
   onSettingsClose,
   projectId,
   requestedSettings,
   slug,
 }: {
+  githubResult?: string;
   linearResult?: string;
   onSettingsClose: () => void;
   projectId: string;
@@ -180,6 +233,7 @@ function ProjectNav({
               <ProjectSettings
                 projectID={projectId as never}
                 requestedSection={requestedSettings}
+                githubResult={githubResult}
                 linearResult={linearResult}
                 onUrlClose={onSettingsClose}
               >

--- a/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.test.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+const actions = vi.hoisted(() => ({
+  check: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => ({ pathname: "/dashboard/project/project/slug/requests", searchStr: "" }),
+  useRouter: () => ({ history: { push: vi.fn() } }),
+}));
+
+vi.mock("@wish/convex-backend/api", () => ({
+  api: {
+    workItemHandoffs: {
+      check: "check",
+      getSurface: "getSurface",
+      send: "send",
+    },
+  },
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: (reference: string) => actions[reference as "check" | "send"],
+  useQuery: (_reference: string, arguments_: { provider: "github" | "linear" }) => ({
+    connection: {
+      destinationLabel: arguments_.provider === "github" ? "wish/repo" : "WISH",
+      health: "active",
+    },
+    handoff: null,
+  }),
+}));
+
+import WorkItemHandoffAction from "./WorkItemHandoffAction";
+
+beforeAll(() => {
+  Object.defineProperty(window, "PointerEvent", { value: MouseEvent });
+  Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+    value: () => false,
+  });
+  Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+    value: () => undefined,
+  });
+  Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+    value: () => undefined,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("WorkItemHandoffAction", () => {
+  it("keeps a provider disabled after the menu closes while its send is pending", async () => {
+    let finishSend = () => {};
+    actions.send.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        finishSend = resolve;
+      }),
+    );
+
+    render(
+      <WorkItemHandoffAction
+        request={{ _id: "request", project: "project" } as never}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: /work trackers/i }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    const firstGitHubItem = (await screen.findByText("GitHub Issues")).closest(
+      '[role="menuitem"]',
+    );
+    expect(firstGitHubItem).not.toBeNull();
+    fireEvent.keyDown(firstGitHubItem!, { key: "Enter" });
+
+    await waitFor(() => expect(actions.send).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText("GitHub Issues")).toBeNull());
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: /work trackers/i }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    const reopenedGitHubItem = (await screen.findByText("GitHub Issues")).closest(
+      '[role="menuitem"]',
+    );
+    expect(reopenedGitHubItem?.hasAttribute("data-disabled")).toBe(true);
+    fireEvent.keyDown(reopenedGitHubItem!, { key: "Enter" });
+    expect(actions.send).toHaveBeenCalledTimes(1);
+
+    finishSend();
+  });
+});

--- a/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.tsx
+++ b/apps/wish-start/src/components/Request/DetailView/WorkItemHandoffAction.tsx
@@ -4,23 +4,62 @@ import { useLocation, useRouter } from "@tanstack/react-router";
 import { api } from "@wish/convex-backend/api";
 import type { Doc } from "@wish/convex-backend/data-model";
 import { useAction, useQuery } from "convex/react";
-import { ExternalLink, RefreshCw, Send, Settings2, Wrench } from "lucide-react";
+import {
+  ChartNoAxesGantt,
+  ChevronDown,
+  ExternalLink,
+  Github,
+  RefreshCw,
+  Send,
+  Settings2,
+  Wrench,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 import { getWorkItemHandoffAction } from "@/lib/workItemHandoffUi";
 import { getWorkTrackerError } from "@/lib/workTrackerErrors";
 
-function errorMessage(error: unknown, fallback: string) {
-  return getWorkTrackerError(error)?.message ?? fallback;
+function providerDetails(provider: Doc<"workItemHandoffs">["provider"]) {
+  switch (provider) {
+    case "linear":
+      return { label: "Linear", issueLabel: "Linear issue", Icon: ChartNoAxesGantt };
+    case "github":
+      return { label: "GitHub Issues", issueLabel: "GitHub issue", Icon: Github };
+  }
+}
+
+function actionIcon(action: ReturnType<typeof getWorkItemHandoffAction>) {
+  switch (action) {
+    case "connect":
+      return Settings2;
+    case "fix":
+      return Wrench;
+    case "checking":
+      return RefreshCw;
+    case "open":
+      return ExternalLink;
+    case "retry":
+    case "send":
+      return Send;
+  }
 }
 
 function showHandoffResult(handoff: Doc<"workItemHandoffs">) {
+  const details = providerDetails(handoff.provider);
   if (handoff.lifecycle.state === "succeeded") {
     const issue = handoff.lifecycle.externalIdentity;
-    toast.success("Linear issue ready", {
+    toast.success(`${details.issueLabel} ready`, {
       description: (
         <a
           href={issue.url}
@@ -36,17 +75,18 @@ function showHandoffResult(handoff: Doc<"workItemHandoffs">) {
     return;
   }
   if (handoff.lifecycle.state === "failed") {
-    toast.error(handoff.lifecycle.errorMessage);
+    toast.error(
+      handoff.lifecycle.errorMessage ?? `Could not create the ${details.issueLabel}`,
+    );
     return;
   }
   if (handoff.lifecycle.state === "unknown") {
-    toast.warning("Linear delivery is being checked", {
-      description:
-        "Wish will not send the issue twice while the outcome is uncertain.",
+    toast.warning(`${details.label} delivery is being checked`, {
+      description: "Wish will not send the issue twice while the outcome is uncertain.",
     });
     return;
   }
-  toast.message("Creating Linear issue");
+  toast.message(`Creating ${details.issueLabel}`);
 }
 
 export default function WorkItemHandoffAction({
@@ -54,7 +94,74 @@ export default function WorkItemHandoffAction({
 }: {
   request: Doc<"requests">;
 }) {
-  const provider = "linear" as const;
+  const location = useLocation();
+  const router = useRouter();
+  const [workingProviders, setWorkingProviders] = useState({
+    github: false,
+    linear: false,
+  });
+
+  function openSettings() {
+    const search = new URLSearchParams(location.searchStr);
+    search.set("settings", "work-trackers");
+    router.history.push(`${location.pathname}?${search.toString()}`);
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" size="sm" variant="outline">
+          <Send /> Work trackers <ChevronDown className="size-3.5 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <DropdownMenuLabel>
+          <span className="block">External work items</span>
+          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+            Choose exactly where to send this item.
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <ProviderHandoffItem
+          request={request}
+          provider="linear"
+          openSettings={openSettings}
+          working={workingProviders.linear}
+          onWorkingChange={(working) =>
+            setWorkingProviders((current) => ({ ...current, linear: working }))
+          }
+        />
+        <ProviderHandoffItem
+          request={request}
+          provider="github"
+          openSettings={openSettings}
+          working={workingProviders.github}
+          onWorkingChange={(working) =>
+            setWorkingProviders((current) => ({ ...current, github: working }))
+          }
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={openSettings}>
+          <Settings2 /> Manage Work Trackers
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ProviderHandoffItem({
+  onWorkingChange,
+  openSettings,
+  provider,
+  request,
+  working,
+}: {
+  onWorkingChange: (working: boolean) => void;
+  openSettings: () => void;
+  provider: Doc<"workItemHandoffs">["provider"];
+  request: Doc<"requests">;
+  working: boolean;
+}) {
   const surface = useQuery(api.workItemHandoffs.getSurface, {
     projectId: request.project,
     requestId: request._id,
@@ -62,15 +169,15 @@ export default function WorkItemHandoffAction({
   });
   const sendHandoff = useAction(api.workItemHandoffs.send);
   const checkHandoff = useAction(api.workItemHandoffs.check);
-  const location = useLocation();
-  const router = useRouter();
-  const [working, setWorking] = useState(false);
+  const details = providerDetails(provider);
 
   if (!surface) {
     return (
-      <Button type="button" size="sm" variant="outline" disabled>
-        <Spinner /> Loading Linear
-      </Button>
+      <DropdownMenuItem disabled className="py-2.5">
+        <details.Icon />
+        <span className="flex-1">Loading {details.label}</span>
+        <Spinner />
+      </DropdownMenuItem>
     );
   }
 
@@ -80,92 +187,85 @@ export default function WorkItemHandoffAction({
       ? surface.handoff.lifecycle.externalIdentity
       : undefined;
 
-  function openSettings() {
-    const search = new URLSearchParams(location.searchStr);
-    search.set("settings", "work-trackers");
-    router.history.push(`${location.pathname}?${search.toString()}`);
-  }
-
-  async function send() {
-    setWorking(true);
-    try {
-      const result = await sendHandoff({
-        projectId: request.project,
-        requestId: request._id,
-        provider,
-      });
-      showHandoffResult(result);
-    } catch (error) {
-      toast.error(errorMessage(error, "Could not send this item to Linear"));
-    } finally {
-      setWorking(false);
-    }
-  }
-
-  async function check() {
-    setWorking(true);
-    try {
-      const result = await checkHandoff({
-        projectId: request.project,
-        requestId: request._id,
-        provider,
-      });
-      if (result) showHandoffResult(result);
-    } catch (error) {
-      toast.error(errorMessage(error, "Could not check the Linear issue"));
-    } finally {
-      setWorking(false);
-    }
-  }
-
   if (action === "open" && issue) {
     return (
-      <Button size="sm" variant="outline" asChild>
+      <DropdownMenuItem asChild className="py-2.5">
         <a href={issue.url} target="_blank" rel="noreferrer">
-          {issue.identifier} <ExternalLink />
+          <details.Icon />
+          <span className="min-w-0 flex-1">
+            <span className="block font-medium">{details.label}</span>
+            <span className="block truncate text-xs text-muted-foreground">
+              Open {issue.identifier}
+            </span>
+          </span>
+          <ExternalLink />
         </a>
-      </Button>
+      </DropdownMenuItem>
     );
   }
 
-  if (action === "connect" || action === "fix") {
-    return (
-      <Button type="button" size="sm" variant="outline" onClick={openSettings}>
-        {action === "connect" ? <Settings2 /> : <Wrench />}
-        {action === "connect" ? "Connect Linear" : "Fix Linear"}
-      </Button>
-    );
+  const pending = surface.handoff?.lifecycle.state === "pending";
+
+  async function run() {
+    if (action === "connect" || action === "fix") {
+      openSettings();
+      return;
+    }
+    if (working) return;
+    onWorkingChange(true);
+    try {
+      const result =
+        action === "checking"
+          ? await checkHandoff({
+              projectId: request.project,
+              requestId: request._id,
+              provider,
+            })
+          : await sendHandoff({
+              projectId: request.project,
+              requestId: request._id,
+              provider,
+            });
+      if (result) showHandoffResult(result);
+    } catch (error) {
+      const message = getWorkTrackerError(error)?.message ??
+        `Could not ${action === "checking" ? "check" : "send"} the ${details.issueLabel}`;
+      toast.error(message);
+    } finally {
+      onWorkingChange(false);
+    }
   }
 
-  if (action === "checking") {
-    const pending = surface.handoff?.lifecycle.state === "pending";
-    return (
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        disabled={working || pending}
-        onClick={() => void check()}
-      >
-        {working || pending ? <Spinner /> : <RefreshCw />}
-        {working || pending ? "Checking Linear" : "Check Linear"}
-      </Button>
-    );
-  }
+  const description = (() => {
+    switch (action) {
+      case "connect":
+        return "Connect this provider to send";
+      case "fix":
+        return "Connection needs attention";
+      case "checking":
+        return pending ? "Creation is in progress" : "Outcome uncertain — check now";
+      case "retry":
+        return "Previous attempt failed — retry";
+      case "send":
+        return `Send to ${surface.connection?.destinationLabel}`;
+      case "open":
+        return "Open external issue";
+    }
+  })();
+  const StatusIcon = actionIcon(action);
 
   return (
-    <Button
-      type="button"
-      size="sm"
-      disabled={working}
-      onClick={() => void send()}
+    <DropdownMenuItem
+      disabled={working || pending}
+      className="py-2.5"
+      onSelect={() => void run()}
     >
-      {working ? <Spinner /> : <Send />}
-      {working
-        ? "Sending"
-        : action === "retry"
-          ? "Retry Linear"
-          : "Send to Linear"}
-    </Button>
+      <details.Icon />
+      <span className="min-w-0 flex-1">
+        <span className="block font-medium">{details.label}</span>
+        <span className="block truncate text-xs text-muted-foreground">{description}</span>
+      </span>
+      {working ? <Spinner /> : <StatusIcon />}
+    </DropdownMenuItem>
   );
 }

--- a/apps/wish-start/src/components/project/GitHubWorkTrackerCard.tsx
+++ b/apps/wish-start/src/components/project/GitHubWorkTrackerCard.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useAsyncAction } from "#/hooks/useAsyncAction";
+import { api } from "@wish/convex-backend/api";
+import type { Id } from "@wish/convex-backend/data-model";
+import { useAction, useMutation, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { AlertTriangle, Check, Github } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getInitialGitHubRepositoryId } from "@/lib/githubWorkTrackerUi";
+import { getWorkTrackerCallbackMessage } from "@/lib/workTrackerCallbackUi";
+import { getWorkTrackerError } from "@/lib/workTrackerErrors";
+
+import {
+  WorkTrackerCallbackAlert,
+  WorkTrackerCard,
+  WorkTrackerCleanupAlert,
+  WorkTrackerConnectionActions,
+  WorkTrackerConnectionFact,
+  WorkTrackerConfigurationAlert,
+  WorkTrackerDestinationEditor,
+  WorkTrackerSetupFlow,
+  WorkTrackerSetupStep,
+} from "./WorkTrackerSetup";
+
+function errorMessage(error: unknown, fallback: string) {
+  return getWorkTrackerError(error)?.message ??
+    (error instanceof Error && error.message ? error.message : fallback);
+}
+
+export default function GitHubWorkTrackerCard({
+  githubResult,
+  projectId,
+}: {
+  githubResult?: string;
+  projectId: Id<"projects">;
+}) {
+  const settings = useQuery(api.githubWorkTrackerSettings.getGitHubSettings, { projectId });
+  const beginGitHubSetup = useAction(api.githubWorkTrackerOAuth.beginGitHubSetup);
+  const discardGitHubSetup = useMutation(api.githubWorkTrackerOAuth.discardGitHubSetup);
+  const selectGitHubRepository = useAction(
+    api.githubWorkTrackerConnections.selectGitHubRepository,
+  );
+  const listGitHubRepositories = useAction(
+    api.githubWorkTrackerConnections.listGitHubRepositories,
+  );
+  const changeGitHubRepository = useAction(
+    api.githubWorkTrackerConnections.changeGitHubRepository,
+  );
+  const disconnectGitHub = useMutation(api.githubWorkTrackerConnections.disconnectGitHub);
+  const connectionAction = useAsyncAction();
+  const repositoryAction = useAsyncAction();
+  const [availableRepositories, setAvailableRepositories] = useState<Awaited<
+    ReturnType<typeof listGitHubRepositories>
+  > | null>(null);
+  const [repositoryId, setRepositoryId] = useState("");
+  const busy = connectionAction.isLoading || repositoryAction.isLoading;
+
+  async function startSetup(setupId?: Id<"workTrackerOAuthSetups">) {
+    await connectionAction.execute(async () => {
+      try {
+        if (setupId) await discardGitHubSetup({ projectId, setupId });
+        const result = await beginGitHubSetup({ projectId });
+        window.location.assign(result.authorizationUrl);
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not start GitHub authorization"));
+      }
+    });
+  }
+
+  async function discardSetup(setupId: Id<"workTrackerOAuthSetups">) {
+    await connectionAction.execute(async () => {
+      try {
+        await discardGitHubSetup({ projectId, setupId });
+        toast.success("GitHub authorization discarded");
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not discard GitHub authorization"));
+      }
+    });
+  }
+
+  async function loadRepositories() {
+    await repositoryAction.execute(async () => {
+      try {
+        const repositories = await listGitHubRepositories({ projectId });
+        setAvailableRepositories(repositories);
+        setRepositoryId(
+          getInitialGitHubRepositoryId(
+            repositories,
+            settings?.connection?.repository.id,
+          ),
+        );
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not load GitHub repositories"));
+      }
+    });
+  }
+
+  async function saveRepository() {
+    if (!repositoryId) return;
+    await repositoryAction.execute(async () => {
+      try {
+        const result = await changeGitHubRepository({ projectId, repositoryId });
+        setAvailableRepositories(null);
+        toast.success(`GitHub destination changed to ${result.repository.fullName}`);
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not change the GitHub repository"));
+      }
+    });
+  }
+
+  async function disconnect() {
+    await connectionAction.execute(async () => {
+      try {
+        await disconnectGitHub({ projectId });
+        setAvailableRepositories(null);
+        toast.success("GitHub disconnected");
+      } catch (error) {
+        toast.error(errorMessage(error, "Could not disconnect GitHub"));
+      }
+    });
+  }
+
+  const callbackMessage = getWorkTrackerCallbackMessage("github", githubResult);
+  const showCallbackMessage =
+    callbackMessage && (!callbackMessage.successful || Boolean(settings?.setup));
+
+  return (
+    <div className="space-y-5">
+      {showCallbackMessage ? (
+        <WorkTrackerCallbackAlert {...callbackMessage} />
+      ) : null}
+
+      {settings && !settings.configured ? (
+        <WorkTrackerConfigurationAlert
+          provider="GitHub"
+          description="A deployment administrator must configure the GitHub App before Project Owners can use this connection."
+        />
+      ) : null}
+
+      {settings?.cleanupSetupId ? (
+        <WorkTrackerCleanupAlert
+          busy={busy}
+          title="An incomplete GitHub authorization remains"
+          description="No active connection was changed. Discard the incomplete setup before retrying."
+          onDiscard={() => void discardSetup(settings.cleanupSetupId!)}
+        />
+      ) : null}
+
+      <WorkTrackerCard
+        title="GitHub Issues"
+        description="One installation and one repository for this Project Board."
+        icon={<Github className="size-5" />}
+        loading={settings === undefined}
+        configured={settings?.configured ?? false}
+        connectionHealth={
+          settings?.connection?.health === "active"
+            ? "active"
+            : settings?.connection
+              ? "attention"
+              : undefined
+        }
+        unavailableText="GitHub authorization is unavailable until the deployment is configured."
+        setupContent={
+          settings?.setup ? (
+            <AuthorizedGitHubSetup
+              key={settings.setup.id}
+              setup={settings.setup}
+              isSaving={busy}
+              onCancel={() => void discardSetup(settings.setup!.id)}
+              onStartAgain={() => void startSetup(settings.setup!.id)}
+              onSave={async (selectedRepositoryId) => {
+                await connectionAction.execute(async () => {
+                  try {
+                    const result = await selectGitHubRepository({
+                      projectId,
+                      setupId: settings.setup!.id,
+                      repositoryId: selectedRepositoryId,
+                    });
+                    toast.success(`GitHub connected to ${result.repository.fullName}`);
+                  } catch (error) {
+                    toast.error(errorMessage(error, "Could not save the GitHub destination"));
+                  }
+                });
+              }}
+            />
+          ) : undefined
+        }
+        connectedContent={
+          settings?.connection ? (
+            <div className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <WorkTrackerConnectionFact
+                  label="GitHub account"
+                  value={settings.connection.accountLogin}
+                />
+                <WorkTrackerConnectionFact
+                  label="Destination repository"
+                  value={settings.connection.repository.fullName}
+                />
+              </div>
+
+              {availableRepositories ? (
+                <WorkTrackerDestinationEditor
+                  title="Change destination repository"
+                  description="This affects future sends only. Existing GitHub links do not move."
+                  saveLabel="Save repository"
+                  saveDisabled={!repositoryId}
+                  busy={busy}
+                  onSave={() => void saveRepository()}
+                  onCancel={() => setAvailableRepositories(null)}
+                >
+                    <RepositorySelect
+                      repositories={availableRepositories}
+                      repositoryId={repositoryId}
+                      onValueChange={setRepositoryId}
+                    />
+                </WorkTrackerDestinationEditor>
+              ) : null}
+
+              <WorkTrackerConnectionActions
+                provider="GitHub"
+                busy={busy}
+                changeLabel="Change repository"
+                connectLabel="Connect another installation"
+                disconnectLabel="Disconnect GitHub"
+                disconnectDescription="Wish removes only this local connection. The GitHub App stays installed and historical issue links remain available."
+                onChange={() => void loadRepositories()}
+                onConnect={() => void startSetup()}
+                onDisconnect={() => void disconnect()}
+              />
+            </div>
+          ) : undefined
+        }
+        disconnectedContent={
+          <WorkTrackerSetupFlow
+            firstTitle="Install the GitHub App"
+            firstDescription="Grant Wish issue access to the repositories you choose."
+            action={
+              <Button type="button" disabled={busy} onClick={() => void startSetup()}>
+                <Github /> Install GitHub App
+              </Button>
+            }
+            secondTitle="Choose a repository"
+            secondDescription="After installation, choose exactly one repository for future sends."
+          />
+        }
+      />
+    </div>
+  );
+}
+
+function AuthorizedGitHubSetup({
+  isSaving,
+  onCancel,
+  onSave,
+  onStartAgain,
+  setup,
+}: {
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (repositoryId: string) => Promise<void>;
+  onStartAgain: () => void;
+  setup: NonNullable<
+    FunctionReturnType<typeof api.githubWorkTrackerSettings.getGitHubSettings>["setup"]
+  >;
+}) {
+  const [repositoryId, setRepositoryId] = useState(
+    setup.repositories.length === 1 ? setup.repositories[0].id : "",
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
+        <WorkTrackerSetupStep number="1" title="GitHub authorized" complete>
+          {setup.accountLogin} granted access. Temporary user credentials were revoked.
+        </WorkTrackerSetupStep>
+        <div className="hidden items-center text-muted-foreground sm:flex">→</div>
+        <WorkTrackerSetupStep number="2" title="Choose a repository" active>
+          {setup.repositories.length > 0
+            ? "Select the repository that should receive future External Work Items."
+            : "This installation does not expose an available issue repository to Wish."}
+        </WorkTrackerSetupStep>
+      </div>
+
+      {setup.replacesInstallation ? (
+        <Alert>
+          <AlertTriangle />
+          <AlertTitle>This replaces the connected installation</AlertTitle>
+          <AlertDescription>
+            Historical issue links remain unchanged. Only future sends use the new installation.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-muted/20 p-4">
+        {setup.repositories.length > 0 ? (
+          <RepositorySelect
+            repositories={setup.repositories}
+            repositoryId={repositoryId}
+            onValueChange={setRepositoryId}
+          />
+        ) : null}
+        <Button
+          type="button"
+          disabled={!repositoryId || isSaving}
+          onClick={() => void onSave(repositoryId)}
+        >
+          <Check /> Save destination
+        </Button>
+        <Button type="button" variant="ghost" disabled={isSaving} onClick={onCancel}>
+          Cancel setup
+        </Button>
+        <Button type="button" variant="ghost" disabled={isSaving} onClick={onStartAgain}>
+          Start again
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RepositorySelect({
+  onValueChange,
+  repositories,
+  repositoryId,
+}: {
+  onValueChange: (value: string) => void;
+  repositories: { id: string; fullName: string }[];
+  repositoryId: string;
+}) {
+  return (
+    <Select value={repositoryId} onValueChange={onValueChange}>
+      <SelectTrigger className="min-w-72" aria-label="GitHub destination repository">
+        <SelectValue placeholder="Choose a GitHub repository" />
+      </SelectTrigger>
+      <SelectContent>
+        {repositories.map((repository) => (
+          <SelectItem key={repository.id} value={repository.id}>
+            {repository.fullName}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
+++ b/apps/wish-start/src/components/project/LinearWorkTrackerCard.tsx
@@ -5,32 +5,12 @@ import { api } from "@wish/convex-backend/api";
 import type { Id } from "@wish/convex-backend/data-model";
 import { useAction, useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
-import {
-  AlertTriangle,
-  Check,
-  ChartNoAxesGantt,
-  Link2,
-  RefreshCw,
-  Unplug,
-} from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { AlertTriangle, Check, ChartNoAxesGantt, Link2 } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -38,40 +18,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Spinner } from "@/components/ui/spinner";
-import { getInitialLinearTeamId, parseLinearCallbackResult } from "@/lib/linearWorkTrackerUi";
+import { getInitialLinearTeamId } from "@/lib/linearWorkTrackerUi";
+import { getWorkTrackerCallbackMessage } from "@/lib/workTrackerCallbackUi";
 import { getWorkTrackerError } from "@/lib/workTrackerErrors";
 
-const callbackMessages = {
-  authorized: {
-    title: "Linear authorized",
-    description: "Choose the team that should receive new External Work Items.",
-  },
-  invalid_callback: {
-    title: "Linear did not complete authorization",
-    description: "Start the connection again from this page.",
-  },
-  invalid_state: {
-    title: "This Linear connection link expired",
-    description: "OAuth links are single-use and expire after ten minutes. Start again.",
-  },
-  authorization_denied: {
-    title: "Linear authorization was canceled",
-    description: "No active connection was changed.",
-  },
-  linear_exchange_failed: {
-    title: "Linear rejected the authorization exchange",
-    description: "No active connection was changed. Start again or check the Linear app settings.",
-  },
-  linear_discovery_failed: {
-    title: "Wish could not load Linear teams",
-    description: "No active connection was changed. Reauthorize and try again.",
-  },
-  linear_persistence_failed: {
-    title: "Wish could not save the Linear authorization",
-    description: "The new authorization was revoked. Start again.",
-  },
-};
+import {
+  WorkTrackerCallbackAlert,
+  WorkTrackerCard,
+  WorkTrackerCleanupAlert,
+  WorkTrackerConnectionFact,
+  WorkTrackerConnectionActions,
+  WorkTrackerConfigurationAlert,
+  WorkTrackerDestinationEditor,
+  WorkTrackerSetupFlow,
+  WorkTrackerSetupStep,
+} from "./WorkTrackerSetup";
 
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error && error.message ? error.message : fallback;
@@ -169,88 +130,48 @@ export default function LinearWorkTrackerCard({
     });
   }
 
-  const parsedLinearResult = parseLinearCallbackResult(linearResult);
-  const callbackMessage = parsedLinearResult ? callbackMessages[parsedLinearResult] : null;
+  const callbackMessage = getWorkTrackerCallbackMessage("linear", linearResult);
   const showCallbackMessage =
-    callbackMessage && (parsedLinearResult !== "authorized" || Boolean(settings?.setup));
+    callbackMessage && (!callbackMessage.successful || Boolean(settings?.setup));
 
   return (
     <div className="space-y-5">
       {showCallbackMessage ? (
-        <Alert variant={parsedLinearResult === "authorized" ? "default" : "destructive"}>
-          {parsedLinearResult === "authorized" ? <Check /> : <AlertTriangle />}
-          <AlertTitle>{callbackMessage.title}</AlertTitle>
-          <AlertDescription>{callbackMessage.description}</AlertDescription>
-        </Alert>
+        <WorkTrackerCallbackAlert {...callbackMessage} />
       ) : null}
 
       {settings && !settings.configured ? (
-        <Alert variant="destructive">
-          <AlertTriangle />
-          <AlertTitle>Linear is not configured</AlertTitle>
-          <AlertDescription>
-            A deployment administrator must configure Linear OAuth before Project Owners can use
-            this connection.
-          </AlertDescription>
-        </Alert>
+        <WorkTrackerConfigurationAlert
+          provider="Linear"
+          description="A deployment administrator must configure Linear OAuth before Project Owners can use this connection."
+        />
       ) : null}
 
       {settings?.cleanupSetupId ? (
-        <Alert variant="destructive">
-          <AlertTriangle />
-          <AlertTitle>A failed Linear authorization still needs cleanup</AlertTitle>
-          <AlertDescription className="space-y-3">
-            <p>No active connection was changed. Revoke the failed authorization before retrying.</p>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={connectionBusy}
-              onClick={() => void cancelAuthorization(settings.cleanupSetupId!)}
-            >
-              Discard authorization
-            </Button>
-          </AlertDescription>
-        </Alert>
+        <WorkTrackerCleanupAlert
+          busy={connectionBusy}
+          title="A failed Linear authorization still needs cleanup"
+          description="No active connection was changed. Revoke the failed authorization before retrying."
+          onDiscard={() => void cancelAuthorization(settings.cleanupSetupId!)}
+        />
       ) : null}
 
-      <Card className="overflow-hidden border-orange-500/15 bg-card/75 shadow-sm">
-        <CardHeader className="border-b bg-muted/20">
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-lg bg-foreground text-background">
-                <ChartNoAxesGantt className="size-5" />
-              </div>
-              <div>
-                <CardTitle className="text-base">Linear</CardTitle>
-                <p className="mt-0.5 text-sm text-muted-foreground">
-                  One workspace and one destination team for this Project Board.
-                </p>
-              </div>
-            </div>
-            <Badge
-              variant={
-                settings?.connection?.health === "active"
-                  ? "default"
-                  : settings?.connection
-                    ? "destructive"
-                    : "secondary"
-              }
-            >
-              {settings?.connection?.health === "active"
-                ? "Connected"
-                : settings?.connection
-                  ? "Needs attention"
-                  : "Not connected"}
-            </Badge>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-5 pt-5">
-          {settings === undefined ? (
-            <div className="flex min-h-32 items-center justify-center">
-              <Spinner />
-            </div>
-          ) : settings.setup ? (
+      <WorkTrackerCard
+        title="Linear"
+        description="One workspace and one destination team for this Project Board."
+        icon={<ChartNoAxesGantt className="size-5" />}
+        loading={settings === undefined}
+        configured={settings?.configured ?? false}
+        connectionHealth={
+          settings?.connection?.health === "active"
+            ? "active"
+            : settings?.connection
+              ? "attention"
+              : undefined
+        }
+        unavailableText="Linear authorization is unavailable until the deployment is configured."
+        setupContent={
+          settings?.setup ? (
             <AuthorizedLinearSetup
               key={settings.setup.id}
               setup={settings.setup}
@@ -272,25 +193,32 @@ export default function LinearWorkTrackerCard({
                 });
               }}
             />
-          ) : settings.connection ? (
+          ) : undefined
+        }
+        connectedContent={
+          settings?.connection ? (
             <div className="space-y-5">
               <div className="grid gap-3 sm:grid-cols-2">
-                <ConnectionFact label="Workspace" value={settings.connection.organization.name} />
-                <ConnectionFact
+                <WorkTrackerConnectionFact
+                  label="Workspace"
+                  value={settings.connection.organization.name}
+                />
+                <WorkTrackerConnectionFact
                   label="Destination team"
                   value={`${settings.connection.team.name} · ${settings.connection.team.key}`}
                 />
               </div>
 
               {availableTeams ? (
-                <div className="rounded-xl border bg-muted/20 p-4">
-                  <div className="mb-3">
-                    <p className="font-medium">Change destination team</p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      This affects future sends only. Existing Linear links do not move.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
+                <WorkTrackerDestinationEditor
+                  title="Change destination team"
+                  description="This affects future sends only. Existing Linear links do not move."
+                  saveLabel="Save team"
+                  saveDisabled={!selectedTeamId}
+                  busy={connectionBusy}
+                  onSave={() => void saveTeam()}
+                  onCancel={() => setAvailableTeams(null)}
+                >
                     <Select value={selectedTeamId} onValueChange={setSelectedTeamId}>
                       <SelectTrigger className="min-w-64" aria-label="Linear destination team">
                         <SelectValue placeholder="Choose a team" />
@@ -303,92 +231,41 @@ export default function LinearWorkTrackerCard({
                         ))}
                       </SelectContent>
                     </Select>
-                    <Button
-                      type="button"
-                      disabled={!selectedTeamId || connectionBusy}
-                      onClick={() => void saveTeam()}
-                    >
-                      Save team
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={connectionBusy}
-                      onClick={() => setAvailableTeams(null)}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
+                </WorkTrackerDestinationEditor>
               ) : null}
 
-              <div className="flex flex-wrap gap-2 border-t pt-4">
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={connectionBusy}
-                  onClick={() => void loadTeams()}
-                >
-                  <RefreshCw /> Change team
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={connectionBusy}
-                  onClick={() => void startAuthorization(true)}
-                >
-                  <Link2 /> Connect another workspace
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button type="button" variant="ghost" disabled={connectionBusy}>
-                      <Unplug /> Disconnect
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Disconnect Linear?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Wish will revoke its Linear access. Historical External Work Item links stay
-                        available, and Linear issues are never deleted.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => void disconnect()}>
-                        Disconnect Linear
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </div>
+              <WorkTrackerConnectionActions
+                provider="Linear"
+                busy={connectionBusy}
+                changeLabel="Change team"
+                connectLabel="Connect another workspace"
+                disconnectLabel="Disconnect Linear"
+                disconnectDescription="Wish will revoke its Linear access. Historical External Work Item links stay available, and Linear issues are never deleted."
+                onChange={() => void loadTeams()}
+                onConnect={() => void startAuthorization(true)}
+                onDisconnect={() => void disconnect()}
+              />
             </div>
-          ) : settings.configured ? (
-            <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
-              <SetupStep number="1" title="Authorize Linear" active>
-                A Linear workspace admin grants Wish read and issue-creation access.
-                <div className="mt-4">
-                  <Button
-                    type="button"
-                    disabled={connectionBusy}
-                    onClick={() => void startAuthorization()}
-                  >
-                    <Link2 /> Authorize Linear
-                  </Button>
-                </div>
-              </SetupStep>
-              <div className="hidden items-center text-muted-foreground sm:flex">→</div>
-              <SetupStep number="2" title="Choose a team">
-                After authorization, choose exactly one destination team for future sends.
-              </SetupStep>
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Linear authorization is unavailable until the deployment is configured.
-            </p>
-          )}
-        </CardContent>
-      </Card>
+          ) : undefined
+        }
+        disconnectedContent={
+          <WorkTrackerSetupFlow
+            firstTitle="Authorize Linear"
+            firstDescription="A Linear workspace admin grants Wish read and issue-creation access."
+            action={
+              <Button
+                type="button"
+                disabled={connectionBusy}
+                onClick={() => void startAuthorization()}
+              >
+                <Link2 /> Authorize Linear
+              </Button>
+            }
+            secondTitle="Choose a team"
+            secondDescription="After authorization, choose exactly one destination team for future sends."
+          />
+        }
+      />
     </div>
   );
 }
@@ -413,15 +290,15 @@ function AuthorizedLinearSetup({
   return (
     <div className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
-        <SetupStep number="1" title="Linear authorized" complete>
+        <WorkTrackerSetupStep number="1" title="Linear authorized" complete>
           {setup.organization.name} granted access. Credentials stay encrypted in Wish.
-        </SetupStep>
+        </WorkTrackerSetupStep>
         <div className="hidden items-center text-muted-foreground sm:flex">→</div>
-        <SetupStep number="2" title="Choose a team" active>
+        <WorkTrackerSetupStep number="2" title="Choose a team" active>
           {setup.teams.length > 0
             ? "Select the Linear team that should receive future External Work Items."
             : "This installation does not expose any teams to Wish."}
-        </SetupStep>
+        </WorkTrackerSetupStep>
       </div>
 
       {setup.replacesWorkspace ? (
@@ -459,45 +336,6 @@ function AuthorizedLinearSetup({
           Start again
         </Button>
       </div>
-    </div>
-  );
-}
-
-function SetupStep({
-  active,
-  children,
-  complete,
-  number,
-  title,
-}: {
-  active?: boolean;
-  children: ReactNode;
-  complete?: boolean;
-  number: string;
-  title: string;
-}) {
-  return (
-    <div
-      className={`rounded-xl border p-4 ${active ? "border-orange-500/30 bg-orange-500/5" : "bg-muted/15"}`}
-    >
-      <div className="flex items-center gap-2">
-        <span
-          className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${complete ? "bg-foreground text-background" : active ? "bg-orange-600 text-white" : "bg-muted text-muted-foreground"}`}
-        >
-          {complete ? <Check className="size-3.5" /> : number}
-        </span>
-        <p className="font-medium">{title}</p>
-      </div>
-      <div className="mt-2 text-sm leading-6 text-muted-foreground">{children}</div>
-    </div>
-  );
-}
-
-function ConnectionFact({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border bg-muted/15 p-4">
-      <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">{label}</p>
-      <p className="mt-1 font-medium">{value}</p>
     </div>
   );
 }

--- a/apps/wish-start/src/components/project/ProjectSettings.tsx
+++ b/apps/wish-start/src/components/project/ProjectSettings.tsx
@@ -15,6 +15,7 @@ import ProjectWorkTrackersManager from "./ProjectWorkTrackersManager";
 interface ProjectSettingsProps {
   projectID: Id<"projects">;
   children: ReactElement;
+  githubResult?: string;
   linearResult?: string;
   onUrlClose?: () => void;
   requestedSection?: string;
@@ -22,6 +23,7 @@ interface ProjectSettingsProps {
 
 export default function ProjectSettings({
   children,
+  githubResult,
   linearResult,
   onUrlClose,
   projectID,
@@ -52,7 +54,13 @@ export default function ProjectSettings({
     {
       key: "work-trackers",
       label: "Work Trackers",
-      content: <ProjectWorkTrackersManager projectId={projectID} linearResult={linearResult} />,
+      content: (
+        <ProjectWorkTrackersManager
+          projectId={projectID}
+          githubResult={githubResult}
+          linearResult={linearResult}
+        />
+      ),
     },
   ];
 

--- a/apps/wish-start/src/components/project/ProjectWorkTrackersManager.tsx
+++ b/apps/wish-start/src/components/project/ProjectWorkTrackersManager.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import type { Id } from "@wish/convex-backend/data-model";
-import { CircleDot } from "lucide-react";
+import { Waypoints } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 
+import GitHubWorkTrackerCard from "./GitHubWorkTrackerCard";
 import LinearWorkTrackerCard from "./LinearWorkTrackerCard";
 
 export default function ProjectWorkTrackersManager({
+  githubResult,
   linearResult,
   projectId,
 }: {
+  githubResult?: string;
   linearResult?: string;
   projectId: Id<"projects">;
 }) {
@@ -28,11 +31,12 @@ export default function ProjectWorkTrackersManager({
           variant="outline"
           className="mr-8 border-orange-500/30 text-orange-700 dark:text-orange-300"
         >
-          <CircleDot /> Linear first
+          <Waypoints /> 2 providers
         </Badge>
       </div>
 
       <LinearWorkTrackerCard projectId={projectId} linearResult={linearResult} />
+      <GitHubWorkTrackerCard projectId={projectId} githubResult={githubResult} />
     </div>
   );
 }

--- a/apps/wish-start/src/components/project/WorkTrackerSetup.tsx
+++ b/apps/wish-start/src/components/project/WorkTrackerSetup.tsx
@@ -1,0 +1,319 @@
+import {
+  AlertTriangle,
+  Check,
+  Link2,
+  RefreshCw,
+  Unplug,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+
+export function WorkTrackerCallbackAlert({
+  description,
+  onDismiss,
+  successful,
+  title,
+}: {
+  description: string;
+  onDismiss?: () => void;
+  successful: boolean;
+  title: string;
+}) {
+  return (
+    <Alert variant={successful ? "default" : "destructive"}>
+      {successful ? <Check /> : <AlertTriangle />}
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        {description}
+        {onDismiss ? (
+          <Button type="button" variant="link" className="mt-2 h-auto p-0" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function WorkTrackerConfigurationAlert({
+  description,
+  provider,
+}: {
+  description: string;
+  provider: string;
+}) {
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle />
+      <AlertTitle>{provider} is not configured</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function WorkTrackerCleanupAlert({
+  busy,
+  description,
+  onDiscard,
+  title,
+}: {
+  busy: boolean;
+  description: string;
+  onDiscard: () => void;
+  title: string;
+}) {
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>{description}</p>
+        <Button type="button" variant="outline" disabled={busy} onClick={onDiscard}>
+          Discard authorization
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function WorkTrackerCard({
+  configured,
+  connectedContent,
+  connectionHealth,
+  description,
+  disconnectedContent,
+  icon,
+  loading,
+  setupContent,
+  title,
+  unavailableText,
+}: {
+  configured: boolean;
+  connectedContent?: ReactNode;
+  connectionHealth?: "active" | "attention";
+  description: string;
+  disconnectedContent: ReactNode;
+  icon: ReactNode;
+  loading: boolean;
+  setupContent?: ReactNode;
+  title: string;
+  unavailableText: string;
+}) {
+  return (
+    <Card className="overflow-hidden border-orange-500/15 bg-card/75 shadow-sm">
+      <CardHeader className="border-b bg-muted/20">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-foreground text-background">
+              {icon}
+            </div>
+            <div>
+              <CardTitle className="text-base">{title}</CardTitle>
+              <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+            </div>
+          </div>
+          <Badge
+            variant={
+              connectionHealth === "active"
+                ? "default"
+                : connectionHealth
+                  ? "destructive"
+                  : "secondary"
+            }
+          >
+            {connectionHealth === "active"
+              ? "Connected"
+              : connectionHealth
+                ? "Needs attention"
+                : "Not connected"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5 pt-5">
+        {loading ? (
+          <div className="flex min-h-32 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : setupContent ? (
+          setupContent
+        ) : connectedContent ? (
+          connectedContent
+        ) : configured ? (
+          disconnectedContent
+        ) : (
+          <p className="text-sm text-muted-foreground">{unavailableText}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WorkTrackerDestinationEditor({
+  busy,
+  children,
+  description,
+  onCancel,
+  onSave,
+  saveDisabled,
+  saveLabel,
+  title,
+}: {
+  busy: boolean;
+  children: ReactNode;
+  description: string;
+  onCancel: () => void;
+  onSave: () => void;
+  saveDisabled: boolean;
+  saveLabel: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-muted/20 p-4">
+      <div className="mb-3">
+        <p className="font-medium">{title}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {children}
+        <Button type="button" disabled={saveDisabled || busy} onClick={onSave}>
+          {saveLabel}
+        </Button>
+        <Button type="button" variant="ghost" disabled={busy} onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function WorkTrackerConnectionActions({
+  busy,
+  changeLabel,
+  connectLabel,
+  disconnectDescription,
+  disconnectLabel,
+  onChange,
+  onConnect,
+  onDisconnect,
+  provider,
+}: {
+  busy: boolean;
+  changeLabel: string;
+  connectLabel: string;
+  disconnectDescription: string;
+  disconnectLabel: string;
+  onChange: () => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  provider: string;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 border-t pt-4">
+      <Button type="button" variant="outline" disabled={busy} onClick={onChange}>
+        <RefreshCw /> {changeLabel}
+      </Button>
+      <Button type="button" variant="outline" disabled={busy} onClick={onConnect}>
+        <Link2 /> {connectLabel}
+      </Button>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button type="button" variant="ghost" disabled={busy}>
+            <Unplug /> Disconnect
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect {provider}?</AlertDialogTitle>
+            <AlertDialogDescription>{disconnectDescription}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onDisconnect}>{disconnectLabel}</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export function WorkTrackerSetupFlow({
+  action,
+  firstDescription,
+  firstTitle,
+  secondDescription,
+  secondTitle,
+}: {
+  action: ReactNode;
+  firstDescription: string;
+  firstTitle: string;
+  secondDescription: string;
+  secondTitle: string;
+}) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch">
+      <WorkTrackerSetupStep number="1" title={firstTitle} active>
+        {firstDescription}
+        <div className="mt-4">{action}</div>
+      </WorkTrackerSetupStep>
+      <div className="hidden items-center text-muted-foreground sm:flex">→</div>
+      <WorkTrackerSetupStep number="2" title={secondTitle}>
+        {secondDescription}
+      </WorkTrackerSetupStep>
+    </div>
+  );
+}
+
+export function WorkTrackerSetupStep({
+  active,
+  children,
+  complete,
+  number,
+  title,
+}: {
+  active?: boolean;
+  children: ReactNode;
+  complete?: boolean;
+  number: string;
+  title: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl border p-4 ${active ? "border-orange-500/30 bg-orange-500/5" : "bg-muted/15"}`}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${complete ? "bg-foreground text-background" : active ? "bg-orange-600 text-white" : "bg-muted text-muted-foreground"}`}
+        >
+          {complete ? <Check className="size-3.5" /> : number}
+        </span>
+        <p className="font-medium">{title}</p>
+      </div>
+      <div className="mt-2 text-sm leading-6 text-muted-foreground">{children}</div>
+    </div>
+  );
+}
+
+export function WorkTrackerConnectionFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border bg-muted/15 p-4">
+      <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">{label}</p>
+      <p className="mt-1 font-medium">{value}</p>
+    </div>
+  );
+}

--- a/apps/wish-start/src/lib/githubWorkTrackerUi.test.ts
+++ b/apps/wish-start/src/lib/githubWorkTrackerUi.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getInitialGitHubRepositoryId,
+  parseGitHubCallbackResult,
+} from "./githubWorkTrackerUi";
+
+describe("GitHub Work Tracker UI", () => {
+  it("selects only an unambiguous repository", () => {
+    expect(getInitialGitHubRepositoryId([], "missing")).toBe("");
+    expect(getInitialGitHubRepositoryId([{ id: "new" }], "missing")).toBe("new");
+    expect(
+      getInitialGitHubRepositoryId([{ id: "one" }, { id: "two" }], "missing"),
+    ).toBe("");
+    expect(
+      getInitialGitHubRepositoryId([{ id: "one" }, { id: "two" }], "two"),
+    ).toBe("two");
+  });
+
+  it("accepts only known callback results", () => {
+    expect(parseGitHubCallbackResult("authorized")).toBe("authorized");
+    expect(parseGitHubCallbackResult("toString")).toBeUndefined();
+    expect(parseGitHubCallbackResult("__proto__")).toBeUndefined();
+  });
+});

--- a/apps/wish-start/src/lib/githubWorkTrackerUi.ts
+++ b/apps/wish-start/src/lib/githubWorkTrackerUi.ts
@@ -1,0 +1,27 @@
+export function getInitialGitHubRepositoryId(
+  repositories: { id: string }[],
+  currentRepositoryId?: string,
+) {
+  if (
+    currentRepositoryId &&
+    repositories.some((repository) => repository.id === currentRepositoryId)
+  ) {
+    return currentRepositoryId;
+  }
+  return repositories.length === 1 ? repositories[0].id : "";
+}
+
+const callbackResults = [
+  "authorized",
+  "authorization_denied",
+  "invalid_callback",
+  "invalid_state",
+  "github_exchange_failed",
+  "github_discovery_failed",
+  "github_revocation_failed",
+  "github_persistence_failed",
+] as const;
+
+export function parseGitHubCallbackResult(value?: string | null) {
+  return callbackResults.find((result) => result === value);
+}

--- a/apps/wish-start/src/lib/workTrackerCallbackUi.test.ts
+++ b/apps/wish-start/src/lib/workTrackerCallbackUi.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getWorkTrackerCallbackDismissUrl,
+  getWorkTrackerCallbackMessage,
+} from "./workTrackerCallbackUi";
+
+describe("getWorkTrackerCallbackMessage", () => {
+  it("returns dashboard-safe feedback for provider callbacks without a project route", () => {
+    expect(getWorkTrackerCallbackMessage("github", "invalid_state")).toEqual({
+      title: "This GitHub connection link expired",
+      description: "Installation links are single-use and expire after ten minutes. Start again.",
+      successful: false,
+    });
+    expect(getWorkTrackerCallbackMessage("linear", "invalid_callback")).toEqual({
+      title: "Linear did not complete authorization",
+      description: "Start the connection again from Work Tracker settings.",
+      successful: false,
+    });
+  });
+
+  it("ignores unrecognized callback values", () => {
+    expect(getWorkTrackerCallbackMessage("github", "__proto__")).toBeNull();
+    expect(getWorkTrackerCallbackMessage("linear", "unknown")).toBeNull();
+  });
+
+  it("cleans dashboard callback routing state without dropping unrelated search values", () => {
+    expect(
+      getWorkTrackerCallbackDismissUrl(
+        "/dashboard",
+        "?settings=work-trackers&github=invalid_state&tab=mine",
+        "github",
+      ),
+    ).toBe("/dashboard?tab=mine");
+    expect(
+      getWorkTrackerCallbackDismissUrl(
+        "/dashboard",
+        "?settings=work-trackers&github=invalid_state&linear=invalid_callback",
+        "github",
+      ),
+    ).toBe("/dashboard?settings=work-trackers&linear=invalid_callback");
+  });
+});

--- a/apps/wish-start/src/lib/workTrackerCallbackUi.ts
+++ b/apps/wish-start/src/lib/workTrackerCallbackUi.ts
@@ -1,0 +1,96 @@
+import { parseGitHubCallbackResult } from "./githubWorkTrackerUi";
+import { parseLinearCallbackResult } from "./linearWorkTrackerUi";
+
+const linearMessages = {
+  authorized: {
+    title: "Linear authorized",
+    description: "Choose the team that should receive new External Work Items.",
+  },
+  invalid_callback: {
+    title: "Linear did not complete authorization",
+    description: "Start the connection again from Work Tracker settings.",
+  },
+  invalid_state: {
+    title: "This Linear connection link expired",
+    description: "OAuth links are single-use and expire after ten minutes. Start again.",
+  },
+  authorization_denied: {
+    title: "Linear authorization was canceled",
+    description: "No active connection was changed.",
+  },
+  linear_exchange_failed: {
+    title: "Linear rejected the authorization exchange",
+    description: "No active connection was changed. Start again or check the Linear app settings.",
+  },
+  linear_discovery_failed: {
+    title: "Wish could not load Linear teams",
+    description: "No active connection was changed. Reauthorize and try again.",
+  },
+  linear_persistence_failed: {
+    title: "Wish could not save the Linear authorization",
+    description: "The new authorization was revoked. Start again.",
+  },
+};
+
+const githubMessages = {
+  authorized: {
+    title: "GitHub authorized",
+    description: "Choose the repository that should receive new External Work Items.",
+  },
+  invalid_callback: {
+    title: "GitHub did not complete authorization",
+    description: "Start the connection again from Work Tracker settings.",
+  },
+  invalid_state: {
+    title: "This GitHub connection link expired",
+    description: "Installation links are single-use and expire after ten minutes. Start again.",
+  },
+  authorization_denied: {
+    title: "GitHub authorization was canceled",
+    description: "No active connection was changed.",
+  },
+  github_exchange_failed: {
+    title: "GitHub rejected the authorization exchange",
+    description: "No active connection was changed. Start the installation again.",
+  },
+  github_discovery_failed: {
+    title: "Wish could not load GitHub repositories",
+    description: "No active connection was changed. Check the installation and try again.",
+  },
+  github_revocation_failed: {
+    title: "GitHub credential cleanup is still running",
+    description: "No connection was changed. Wish will keep revoking the temporary credentials.",
+  },
+  github_persistence_failed: {
+    title: "Wish could not save the GitHub authorization",
+    description: "The temporary credentials were revoked. Start again.",
+  },
+};
+
+export function getWorkTrackerCallbackMessage(
+  provider: "github" | "linear",
+  value?: string | null,
+) {
+  switch (provider) {
+    case "github": {
+      const result = parseGitHubCallbackResult(value);
+      return result ? { ...githubMessages[result], successful: result === "authorized" } : null;
+    }
+    case "linear": {
+      const result = parseLinearCallbackResult(value);
+      return result ? { ...linearMessages[result], successful: result === "authorized" } : null;
+    }
+  }
+}
+
+export function getWorkTrackerCallbackDismissUrl(
+  pathname: string,
+  searchString: string,
+  provider: "github" | "linear",
+) {
+  const search = new URLSearchParams(searchString);
+  search.delete(provider);
+  if (!search.has("github") && !search.has("linear")) search.delete("settings");
+  const suffix = search.toString();
+  return `${pathname}${suffix ? `?${suffix}` : ""}`;
+}

--- a/apps/wish-start/vitest.config.ts
+++ b/apps/wish-start/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite-plus/test/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": new URL("./src", import.meta.url).pathname,
+      "#": new URL("./src", import.meta.url).pathname,
+    },
+  },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary
- add one explicit Work trackers menu that routes Requests and Complaints to Linear or GitHub Issues
- add GitHub connection, repository selection, reconnect, disconnect, and callback feedback to Project settings
- keep durable external issue links visible and include the created issue link in success feedback
- share tracker lifecycle, callback, setup, destination, and connection-action presentation across providers
- prevent repeated provider actions while a closed dropdown action is still pending

## Validation
- `bun run check-types`
- `bun run lint`
- `bun run test` — 178 tests passed
- `bun run build`
- `git diff --check`
- thermo-nuclear code-quality review: approved
- review loop: approved

## Stack
Depends on #70.